### PR TITLE
feat: CLI for Pearl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
+        "commander": "^14.0.3",
         "fastify": "^5.0.0",
         "uuidv7": "^1.0.0",
         "yaml": "^2.4.0"
@@ -1652,6 +1653,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
+    "commander": "^14.0.3",
     "fastify": "^5.0.0",
     "uuidv7": "^1.0.0",
     "yaml": "^2.4.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Pearl CLI Entry Point
+ * Main CLI for running Pearl server and managing memories
+ */
+
+import { Command } from 'commander';
+import { serveCommand } from './cli/serve.js';
+import { memoryCommand } from './cli/memory.js';
+import { statsCommand } from './cli/stats.js';
+
+export const program = new Command();
+
+program
+  .name('pearl')
+  .description('Pearl - Memory-enhanced model proxy')
+  .version('0.1.0');
+
+// Register commands
+program.addCommand(serveCommand);
+program.addCommand(memoryCommand);
+program.addCommand(statsCommand);
+
+// Only parse if this is the main module (not imported for testing)
+// Check if running as CLI (not being imported)
+const isMainModule = process.argv[1]?.endsWith('cli.js') || process.argv[1]?.endsWith('cli.ts');
+if (isMainModule) {
+  program.parse();
+}

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,0 +1,173 @@
+/**
+ * Memory Commands
+ * CLI commands for managing agent memories
+ */
+
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { loadConfig } from '../config/loader.js';
+import { MemoryStore, type MemoryType } from '../memory/store.js';
+import type { Config } from '../config/types.js';
+
+export interface MemoryListOptions {
+  agent: string;
+  type?: string;
+  limit?: string;
+  config?: string;
+}
+
+export interface MemoryAddOptions {
+  agent: string;
+  type: string;
+  content: string;
+  tags?: string;
+  config?: string;
+}
+
+export interface MemoryDeleteOptions {
+  config?: string;
+}
+
+export const memoryCommand = new Command('memory')
+  .description('Manage agent memories');
+
+// List memories
+memoryCommand
+  .command('list')
+  .description('List memories for an agent')
+  .requiredOption('-a, --agent <agentId>', 'Agent ID')
+  .option('-t, --type <type>', 'Filter by memory type')
+  .option('-l, --limit <count>', 'Maximum number of memories', '20')
+  .option('-c, --config <path>', 'Path to config file', 'pearl.yaml')
+  .action(async (options: MemoryListOptions) => {
+    try {
+      await runMemoryList(options);
+    } catch (error) {
+      console.error('Failed to list memories:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// Add memory
+memoryCommand
+  .command('add')
+  .description('Add a memory for an agent')
+  .requiredOption('-a, --agent <agentId>', 'Agent ID')
+  .requiredOption('-t, --type <type>', 'Memory type (fact, preference, rule, decision, health, reminder, relationship)')
+  .requiredOption('--content <text>', 'Memory content')
+  .option('--tags <tags>', 'Comma-separated tags')
+  .option('-c, --config <path>', 'Path to config file', 'pearl.yaml')
+  .action(async (options: MemoryAddOptions) => {
+    try {
+      await runMemoryAdd(options);
+    } catch (error) {
+      console.error('Failed to add memory:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// Delete memory
+memoryCommand
+  .command('delete <id>')
+  .description('Delete a memory by ID')
+  .option('-c, --config <path>', 'Path to config file', 'pearl.yaml')
+  .action(async (id: string, options: MemoryDeleteOptions) => {
+    try {
+      await runMemoryDelete(id, options);
+    } catch (error) {
+      console.error('Failed to delete memory:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+async function getStore(configPath: string): Promise<MemoryStore> {
+  const fullPath = resolve(process.cwd(), configPath);
+  const config = await loadConfig(fullPath);
+  return new MemoryStore(config.memory.path);
+}
+
+export async function runMemoryList(options: MemoryListOptions): Promise<void> {
+  const store = await getStore(options.config || 'pearl.yaml');
+  
+  try {
+    const limit = parseInt(options.limit || '20', 10);
+    
+    const memories = store.query({
+      agent_id: options.agent,
+      type: options.type as MemoryType | undefined,
+      limit,
+      orderBy: 'created_at',
+      order: 'desc',
+    });
+
+    if (memories.length === 0) {
+      console.log(`No memories found for agent: ${options.agent}`);
+      return;
+    }
+
+    console.log(`\nMemories for agent: ${options.agent}`);
+    console.log('─'.repeat(60));
+    
+    for (const memory of memories) {
+      console.log(`\nID: ${memory.id}`);
+      console.log(`Type: ${memory.type}`);
+      console.log(`Content: ${memory.content}`);
+      if (memory.tags && memory.tags.length > 0) {
+        console.log(`Tags: ${memory.tags.join(', ')}`);
+      }
+      console.log(`Created: ${new Date(memory.created_at).toISOString()}`);
+      console.log('─'.repeat(60));
+    }
+    
+    console.log(`\nTotal: ${memories.length} memories`);
+  } finally {
+    store.close();
+  }
+}
+
+export async function runMemoryAdd(options: MemoryAddOptions): Promise<void> {
+  const validTypes: MemoryType[] = ['fact', 'preference', 'rule', 'decision', 'health', 'reminder', 'relationship'];
+  
+  if (!validTypes.includes(options.type as MemoryType)) {
+    throw new Error(`Invalid memory type: ${options.type}. Valid types: ${validTypes.join(', ')}`);
+  }
+
+  const store = await getStore(options.config || 'pearl.yaml');
+  
+  try {
+    const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : undefined;
+    
+    const memory = store.create({
+      agent_id: options.agent,
+      type: options.type as MemoryType,
+      content: options.content,
+      tags,
+    });
+
+    console.log(`Memory created successfully!`);
+    console.log(`ID: ${memory.id}`);
+    console.log(`Type: ${memory.type}`);
+    console.log(`Content: ${memory.content}`);
+    if (memory.tags && memory.tags.length > 0) {
+      console.log(`Tags: ${memory.tags.join(', ')}`);
+    }
+  } finally {
+    store.close();
+  }
+}
+
+export async function runMemoryDelete(id: string, options: MemoryDeleteOptions): Promise<void> {
+  const store = await getStore(options.config || 'pearl.yaml');
+  
+  try {
+    const deleted = store.delete(id);
+    
+    if (deleted) {
+      console.log(`Memory ${id} deleted successfully`);
+    } else {
+      console.log(`Memory ${id} not found`);
+    }
+  } finally {
+    store.close();
+  }
+}

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,0 +1,77 @@
+/**
+ * Serve Command
+ * Starts the Pearl HTTP server
+ */
+
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { existsSync } from 'fs';
+import { loadConfig } from '../config/loader.js';
+import { createServer } from '../server/index.js';
+import type { Config } from '../config/types.js';
+
+export interface ServeOptions {
+  config?: string;
+  port?: string;
+  host?: string;
+}
+
+export const serveCommand = new Command('serve')
+  .description('Start the Pearl server')
+  .option('-c, --config <path>', 'Path to config file', 'pearl.yaml')
+  .option('-p, --port <port>', 'Server port (overrides config)')
+  .option('-H, --host <host>', 'Server host (overrides config)')
+  .action(async (options: ServeOptions) => {
+    try {
+      await runServe(options);
+    } catch (error) {
+      console.error('Failed to start server:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+export async function runServe(options: ServeOptions): Promise<void> {
+  // Load config
+  const configPath = resolve(process.cwd(), options.config || 'pearl.yaml');
+  console.log(`Loading config from: ${configPath}`);
+  
+  const config = await loadConfig(configPath);
+
+  // Apply CLI overrides
+  if (options.port) {
+    config.server.port = parseInt(options.port, 10);
+  }
+  if (options.host) {
+    config.server.host = options.host;
+  }
+
+  console.log('Starting Pearl server...');
+  
+  // Create and start server
+  const server = await createServer(config.server);
+  
+  const address = await server.listen({
+    port: config.server.port,
+    host: config.server.host,
+  });
+
+  console.log(`Pearl server listening on ${address}`);
+  console.log('Press Ctrl+C to stop');
+
+  // Graceful shutdown
+  const shutdown = async (signal: string) => {
+    console.log(`\nReceived ${signal}, shutting down...`);
+    
+    try {
+      await server.close();
+      console.log('Shutdown complete');
+      process.exit(0);
+    } catch (error) {
+      console.error('Error during shutdown:', error);
+      process.exit(1);
+    }
+  };
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}

--- a/src/cli/stats.ts
+++ b/src/cli/stats.ts
@@ -1,0 +1,60 @@
+/**
+ * Stats Command
+ * Display Pearl usage statistics
+ */
+
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { loadConfig } from '../config/loader.js';
+import { MemoryStore } from '../memory/store.js';
+import type { Config } from '../config/types.js';
+
+export interface StatsOptions {
+  config?: string;
+}
+
+export const statsCommand = new Command('stats')
+  .description('Display Pearl usage statistics')
+  .option('-c, --config <path>', 'Path to config file', 'pearl.yaml')
+  .action(async (options: StatsOptions) => {
+    try {
+      await runStats(options);
+    } catch (error) {
+      console.error('Failed to get stats:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+export async function runStats(options: StatsOptions): Promise<void> {
+  const configPath = resolve(process.cwd(), options.config || 'pearl.yaml');
+  const config = await loadConfig(configPath);
+  
+  const store = new MemoryStore(config.memory.path);
+  
+  try {
+    const stats = store.getStats();
+    
+    console.log('\nPearl Statistics');
+    console.log('═'.repeat(40));
+    console.log(`Total Memories: ${stats.totalMemories}`);
+    console.log(`Total Agents: ${Object.keys(stats.byAgent).length}`);
+    
+    if (stats.byType && Object.keys(stats.byType).length > 0) {
+      console.log('\nMemories by Type:');
+      for (const [type, count] of Object.entries(stats.byType)) {
+        console.log(`  ${type}: ${count}`);
+      }
+    }
+    
+    if (stats.byAgent && Object.keys(stats.byAgent).length > 0) {
+      console.log('\nMemories by Agent:');
+      for (const [agent, count] of Object.entries(stats.byAgent)) {
+        console.log(`  ${agent}: ${count}`);
+      }
+    }
+    
+    console.log('═'.repeat(40));
+  } finally {
+    store.close();
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,378 @@
+/**
+ * CLI Tests
+ * Tests for the Pearl CLI commands
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { MemoryStore } from '../src/memory/store.js';
+
+// Mock modules - factory must not reference outside variables
+vi.mock('../src/server/index.js', () => {
+  const mockListen = vi.fn().mockResolvedValue('http://localhost:8080');
+  const mockClose = vi.fn().mockResolvedValue(undefined);
+  const mockServer = { listen: mockListen, close: mockClose };
+  return {
+    createServer: vi.fn().mockResolvedValue(mockServer),
+  };
+});
+
+// Import after mocking
+import { runServe } from '../src/cli/serve.js';
+import { runMemoryList, runMemoryAdd, runMemoryDelete } from '../src/cli/memory.js';
+import { runStats } from '../src/cli/stats.js';
+import { createServer } from '../src/server/index.js';
+
+describe('CLI', () => {
+  let tempDir: string;
+  let configPath: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Create temp directory for test files
+    tempDir = mkdtempSync(join(tmpdir(), 'pearl-cli-test-'));
+    dbPath = join(tempDir, 'test.db');
+    configPath = join(tempDir, 'pearl.yaml');
+    
+    // Create test config
+    const config = `
+server:
+  port: 8080
+  host: 0.0.0.0
+
+memory:
+  store: sqlite
+  path: ${dbPath}
+
+extraction:
+  enabled: false
+  model: ollama/llama3.2:3b
+  async: false
+  minConfidence: 0.7
+  extractFromAssistant: false
+  dedupWindowSeconds: 300
+
+embedding:
+  provider: ollama
+  model: nomic-embed-text
+  dimensions: 768
+
+retrieval:
+  maxMemories: 10
+  minSimilarity: 0.7
+  tokenBudget: 500
+  recencyBoost: true
+
+routing:
+  classifier: ollama/llama3.2:3b
+  defaultModel: anthropic/claude-sonnet-4-20250514
+  rules: []
+
+backends:
+  anthropic:
+    apiKey: test-key
+`;
+    writeFileSync(configPath, config);
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('serve command', () => {
+    it('should start server with config', async () => {
+      // runServe will set up signal handlers and not return until shutdown
+      // For testing, we just verify it calls createServer correctly
+      const servePromise = runServe({ config: configPath });
+      
+      // Wait for server to start
+      await vi.waitFor(() => {
+        expect(createServer).toHaveBeenCalled();
+      });
+      
+      // Get the mock server that was created
+      const mockServer = await (createServer as ReturnType<typeof vi.fn>).mock.results[0].value;
+      expect(mockServer.listen).toHaveBeenCalledWith({
+        port: 8080,
+        host: '0.0.0.0',
+      });
+    });
+
+    it('should apply CLI port override', async () => {
+      const servePromise = runServe({ config: configPath, port: '9090' });
+      
+      await vi.waitFor(() => {
+        expect(createServer).toHaveBeenCalled();
+      });
+      
+      const mockServer = await (createServer as ReturnType<typeof vi.fn>).mock.results[0].value;
+      expect(mockServer.listen).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 9090 })
+      );
+    });
+
+    it('should apply CLI host override', async () => {
+      const servePromise = runServe({ config: configPath, host: '127.0.0.1' });
+      
+      await vi.waitFor(() => {
+        expect(createServer).toHaveBeenCalled();
+      });
+      
+      const mockServer = await (createServer as ReturnType<typeof vi.fn>).mock.results[0].value;
+      expect(mockServer.listen).toHaveBeenCalledWith(
+        expect.objectContaining({ host: '127.0.0.1' })
+      );
+    });
+
+    it('should use defaults when no config file exists', async () => {
+      const servePromise = runServe({ config: '/nonexistent/pearl.yaml' });
+      
+      await vi.waitFor(() => {
+        expect(createServer).toHaveBeenCalled();
+      });
+      
+      const mockServer = await (createServer as ReturnType<typeof vi.fn>).mock.results[0].value;
+      expect(mockServer.listen).toHaveBeenCalledWith({
+        port: 8080,
+        host: '0.0.0.0',
+      });
+    });
+  });
+
+  describe('memory commands', () => {
+    it('should list memories for an agent', async () => {
+      // First add a memory
+      const store = new MemoryStore(dbPath);
+      store.create({
+        agent_id: 'test-agent',
+        type: 'fact',
+        content: 'Test fact memory',
+        tags: ['test'],
+      });
+      store.close();
+
+      // Mock console.log to capture output
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runMemoryList({
+          agent: 'test-agent',
+          config: configPath,
+        });
+
+        expect(logs.some(l => l.includes('test-agent'))).toBe(true);
+        expect(logs.some(l => l.includes('Test fact memory'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+    });
+
+    it('should list memories filtered by type', async () => {
+      // Add memories of different types
+      const store = new MemoryStore(dbPath);
+      store.create({
+        agent_id: 'test-agent',
+        type: 'fact',
+        content: 'Fact memory',
+      });
+      store.create({
+        agent_id: 'test-agent',
+        type: 'preference',
+        content: 'Preference memory',
+      });
+      store.close();
+
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runMemoryList({
+          agent: 'test-agent',
+          type: 'fact',
+          config: configPath,
+        });
+
+        expect(logs.some(l => l.includes('Fact memory'))).toBe(true);
+        expect(logs.some(l => l.includes('Preference memory'))).toBe(false);
+      } finally {
+        console.log = originalLog;
+      }
+    });
+
+    it('should add a memory', async () => {
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runMemoryAdd({
+          agent: 'test-agent',
+          type: 'rule',
+          content: 'Always be helpful',
+          tags: 'important,rule',
+          config: configPath,
+        });
+
+        expect(logs.some(l => l.includes('Memory created successfully'))).toBe(true);
+        expect(logs.some(l => l.includes('Always be helpful'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+
+      // Verify memory was created
+      const store = new MemoryStore(dbPath);
+      const memories = store.query({ agent_id: 'test-agent' });
+      store.close();
+
+      expect(memories).toHaveLength(1);
+      expect(memories[0].content).toBe('Always be helpful');
+      expect(memories[0].type).toBe('rule');
+      expect(memories[0].tags).toEqual(['important', 'rule']);
+    });
+
+    it('should reject invalid memory type', async () => {
+      await expect(
+        runMemoryAdd({
+          agent: 'test-agent',
+          type: 'invalid-type',
+          content: 'Test content',
+          config: configPath,
+        })
+      ).rejects.toThrow('Invalid memory type');
+    });
+
+    it('should delete a memory', async () => {
+      // First add a memory
+      const store = new MemoryStore(dbPath);
+      const memory = store.create({
+        agent_id: 'test-agent',
+        type: 'fact',
+        content: 'To be deleted',
+      });
+      store.close();
+
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runMemoryDelete(memory.id, { config: configPath });
+
+        expect(logs.some(l => l.includes('deleted successfully'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+
+      // Verify memory was deleted
+      const store2 = new MemoryStore(dbPath);
+      const deleted = store2.get(memory.id);
+      store2.close();
+
+      expect(deleted).toBeUndefined();
+    });
+
+    it('should handle deleting non-existent memory', async () => {
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runMemoryDelete('non-existent-id', { config: configPath });
+
+        expect(logs.some(l => l.includes('not found'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+    });
+
+    it('should show empty list message when no memories', async () => {
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runMemoryList({
+          agent: 'empty-agent',
+          config: configPath,
+        });
+
+        expect(logs.some(l => l.includes('No memories found'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+    });
+  });
+
+  describe('stats command', () => {
+    it('should display statistics', async () => {
+      // Add some memories
+      const store = new MemoryStore(dbPath);
+      store.create({
+        agent_id: 'agent1',
+        type: 'fact',
+        content: 'Fact 1',
+      });
+      store.create({
+        agent_id: 'agent1',
+        type: 'preference',
+        content: 'Preference 1',
+      });
+      store.create({
+        agent_id: 'agent2',
+        type: 'rule',
+        content: 'Rule 1',
+      });
+      store.close();
+
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runStats({ config: configPath });
+
+        expect(logs.some(l => l.includes('Pearl Statistics'))).toBe(true);
+        expect(logs.some(l => l.includes('Total Memories: 3'))).toBe(true);
+        expect(logs.some(l => l.includes('Total Agents: 2'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+    });
+
+    it('should show empty stats', async () => {
+      const logs: string[] = [];
+      const originalLog = console.log;
+      console.log = (msg: string) => logs.push(String(msg));
+
+      try {
+        await runStats({ config: configPath });
+
+        expect(logs.some(l => l.includes('Total Memories: 0'))).toBe(true);
+      } finally {
+        console.log = originalLog;
+      }
+    });
+  });
+
+  describe('command registration', () => {
+    it('should export all command functions', async () => {
+      expect(typeof runServe).toBe('function');
+      expect(typeof runMemoryList).toBe('function');
+      expect(typeof runMemoryAdd).toBe('function');
+      expect(typeof runMemoryDelete).toBe('function');
+      expect(typeof runStats).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements the Pearl CLI for running the server and managing memories.

## Commands Implemented
```bash
pearl serve [--config pearl.yaml] [--port 8080] [--host 0.0.0.0]
pearl memory list --agent <agentId> [--type <type>] [--limit <n>]
pearl memory add --agent <agentId> --type <type> --content "..." [--tags a,b,c]
pearl memory delete <id>
pearl stats
```

## Changes
- **src/cli.ts**: Main CLI entry point using commander
- **src/cli/serve.ts**: Server startup command with graceful shutdown
- **src/cli/memory.ts**: Memory CRUD commands
- **src/cli/stats.ts**: Statistics display command  
- **tests/cli.test.ts**: 14 comprehensive tests

## Features
- Config file loading with CLI overrides
- Graceful fallback when no config file exists
- Memory type validation
- Proper error handling and exit codes

Closes #12