### PR TITLE
feat(optimization): add PromptRewriter for token-efficient prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,12 @@ export { Pearl } from './pearl.js';
 export { ModelRouter } from './routing/router.js';
 export type { RoutingResult, RouterOptions } from './routing/router.js';
 export type { RequestClassification, RoutingRule } from './routing/types.js';
+
+// Optimization exports
+export { PromptRewriter } from './optimization/rewriter.js';
+export type {
+  RewriteResult,
+  RewriterStats,
+  RewriterConfig,
+  LLMProvider as RewriterLLMProvider,
+} from './optimization/rewriter.js';

--- a/src/optimization/rewriter.ts
+++ b/src/optimization/rewriter.ts
@@ -1,0 +1,323 @@
+/**
+ * Prompt Rewriter
+ * Optimizes user prompts for clarity and token efficiency
+ */
+
+import type { ChatMessage } from '../types.js';
+
+// Token estimation: ~4 chars per token
+const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
+
+export interface RewriteResult {
+  original: string;
+  rewritten: string;
+  originalTokens: number;
+  rewrittenTokens: number;
+  tokensSaved: number;
+  wasRewritten: boolean;
+}
+
+export interface RewriterStats {
+  totalPrompts: number;
+  rewrittenPrompts: number;
+  totalTokensSaved: number;
+  averageSavingsPercent: number;
+}
+
+export interface RewriterConfig {
+  enabled: boolean;
+  model?: string;
+  minTokensToRewrite?: number;  // Don't rewrite prompts shorter than this
+  maxSavingsPercent?: number;   // Cap to prevent over-aggressive rewrites
+  preserveFormatting?: boolean; // Keep code blocks, lists, etc.
+}
+
+export interface LLMProvider {
+  complete(prompt: string): Promise<string>;
+}
+
+const DEFAULT_CONFIG: Required<RewriterConfig> = {
+  enabled: true,
+  model: 'ollama/llama3.2:3b',
+  minTokensToRewrite: 20,      // Don't rewrite short prompts
+  maxSavingsPercent: 50,       // Don't reduce by more than 50%
+  preserveFormatting: true,
+};
+
+const REWRITE_PROMPT = `Rewrite this user prompt to be clear and efficient for an AI model.
+Rules:
+- Preserve ALL information and intent
+- Remove redundancy and filler words (um, like, you know, basically, etc.)
+- Clarify ambiguous phrasing
+- Be direct and specific
+- Do NOT add information not present in the original
+- Keep code blocks, URLs, and technical terms exactly as-is
+- If the prompt is already efficient, return it unchanged
+
+Original prompt:
+"""
+{prompt}
+"""
+
+Rewritten prompt (just the rewritten text, nothing else):`;
+
+/**
+ * Check if prompt contains content that should not be rewritten
+ */
+function hasPreservableContent(text: string): boolean {
+  // Code blocks
+  if (/```[\s\S]*?```/m.test(text)) return true;
+  // Inline code
+  if (/`[^`]+`/.test(text)) return true;
+  // URLs
+  if (/https?:\/\/[^\s]+/.test(text)) return true;
+  // JSON
+  if (/^\s*[{[]/.test(text)) return true;
+  // Very structured content (numbered lists, etc.)
+  if (/^\s*\d+\.\s/m.test(text)) return true;
+  
+  return false;
+}
+
+/**
+ * Check if prompt is likely already efficient
+ */
+function isLikelyEfficient(text: string): boolean {
+  const tokens = estimateTokens(text);
+  
+  // Very short prompts are already efficient
+  if (tokens < 15) return true;
+  
+  // Calculate word-to-token ratio (efficient prompts have fewer filler words)
+  const words = text.split(/\s+/).filter(w => w.length > 0);
+  const avgWordLen = words.reduce((sum, w) => sum + w.length, 0) / words.length;
+  
+  // High average word length suggests technical/specific content
+  if (avgWordLen > 6) return true;
+  
+  // Check for filler word patterns
+  const fillerPatterns = [
+    /\bum\b/i, /\buh\b/i, /\blike\b/i, /\byou know\b/i,
+    /\bbasically\b/i, /\bactually\b/i, /\breally\b/i,
+    /\bjust\b/i, /\bkind of\b/i, /\bsort of\b/i,
+    /\bi was wondering\b/i, /\bcould you please\b/i,
+    /\bi would like\b/i, /\bif you don't mind\b/i,
+  ];
+  
+  const hasFillers = fillerPatterns.some(p => p.test(text));
+  return !hasFillers;
+}
+
+export class PromptRewriter {
+  private config: Required<RewriterConfig>;
+  private provider?: LLMProvider;
+  private stats: RewriterStats;
+
+  constructor(config: Partial<RewriterConfig> = {}, provider?: LLMProvider) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.provider = provider;
+    this.stats = {
+      totalPrompts: 0,
+      rewrittenPrompts: 0,
+      totalTokensSaved: 0,
+      averageSavingsPercent: 0,
+    };
+  }
+
+  /**
+   * Rewrite a single prompt for efficiency
+   */
+  async rewrite(prompt: string): Promise<RewriteResult> {
+    this.stats.totalPrompts++;
+    
+    const originalTokens = estimateTokens(prompt);
+    
+    // If disabled, pass through
+    if (!this.config.enabled) {
+      return this.passthrough(prompt, originalTokens);
+    }
+
+    // Don't rewrite very short prompts
+    if (originalTokens < this.config.minTokensToRewrite) {
+      return this.passthrough(prompt, originalTokens);
+    }
+
+    // Don't rewrite prompts with code/URLs/structured content
+    if (this.config.preserveFormatting && hasPreservableContent(prompt)) {
+      return this.passthrough(prompt, originalTokens);
+    }
+
+    // Don't rewrite already-efficient prompts
+    if (isLikelyEfficient(prompt)) {
+      return this.passthrough(prompt, originalTokens);
+    }
+
+    // No provider configured, use heuristic rewriting
+    if (!this.provider) {
+      return this.heuristicRewrite(prompt, originalTokens);
+    }
+
+    // Use LLM for intelligent rewriting
+    try {
+      const rewritten = await this.llmRewrite(prompt);
+      return this.createResult(prompt, rewritten, originalTokens);
+    } catch (error) {
+      // Fall back to heuristic on error
+      console.error('LLM rewrite failed, using heuristic:', error);
+      return this.heuristicRewrite(prompt, originalTokens);
+    }
+  }
+
+  /**
+   * Rewrite the last user message in a conversation
+   */
+  async rewriteMessages(messages: ChatMessage[]): Promise<{
+    messages: ChatMessage[];
+    result?: RewriteResult;
+  }> {
+    if (!this.config.enabled) {
+      return { messages };
+    }
+
+    // Find the last user message (iterate backwards for compatibility)
+    let lastUserIdx = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        lastUserIdx = i;
+        break;
+      }
+    }
+    if (lastUserIdx === -1) {
+      return { messages };
+    }
+
+    const userMessage = messages[lastUserIdx];
+    const result = await this.rewrite(userMessage.content);
+
+    if (!result.wasRewritten) {
+      return { messages };
+    }
+
+    // Create new messages array with rewritten content
+    const newMessages = [...messages];
+    newMessages[lastUserIdx] = {
+      ...userMessage,
+      content: result.rewritten,
+    };
+
+    return { messages: newMessages, result };
+  }
+
+  /**
+   * Get rewriter statistics
+   */
+  getStats(): RewriterStats {
+    return { ...this.stats };
+  }
+
+  /**
+   * Reset statistics
+   */
+  resetStats(): void {
+    this.stats = {
+      totalPrompts: 0,
+      rewrittenPrompts: 0,
+      totalTokensSaved: 0,
+      averageSavingsPercent: 0,
+    };
+  }
+
+  private passthrough(prompt: string, tokens: number): RewriteResult {
+    return {
+      original: prompt,
+      rewritten: prompt,
+      originalTokens: tokens,
+      rewrittenTokens: tokens,
+      tokensSaved: 0,
+      wasRewritten: false,
+    };
+  }
+
+  private createResult(original: string, rewritten: string, originalTokens: number): RewriteResult {
+    const rewrittenTokens = estimateTokens(rewritten);
+    let tokensSaved = originalTokens - rewrittenTokens;
+    
+    // Don't allow negative savings (rewrite made it longer)
+    if (tokensSaved < 0) {
+      return this.passthrough(original, originalTokens);
+    }
+
+    // Cap savings to prevent over-aggressive rewrites
+    const savingsPercent = (tokensSaved / originalTokens) * 100;
+    if (savingsPercent > this.config.maxSavingsPercent) {
+      // Rewrite was too aggressive, might have lost meaning
+      return this.passthrough(original, originalTokens);
+    }
+
+    // Update stats
+    this.stats.rewrittenPrompts++;
+    this.stats.totalTokensSaved += tokensSaved;
+    this.stats.averageSavingsPercent = 
+      (this.stats.totalTokensSaved / (this.stats.rewrittenPrompts * originalTokens)) * 100;
+
+    return {
+      original,
+      rewritten,
+      originalTokens,
+      rewrittenTokens,
+      tokensSaved,
+      wasRewritten: tokensSaved > 0,
+    };
+  }
+
+  private async llmRewrite(prompt: string): Promise<string> {
+    if (!this.provider) {
+      throw new Error('No LLM provider configured');
+    }
+
+    const rewritePrompt = REWRITE_PROMPT.replace('{prompt}', prompt);
+    const response = await this.provider.complete(rewritePrompt);
+    
+    // Clean up the response
+    return response.trim();
+  }
+
+  private heuristicRewrite(prompt: string, originalTokens: number): RewriteResult {
+    let rewritten = prompt;
+
+    // Remove common filler phrases
+    const fillerRemovals: [RegExp, string][] = [
+      [/\b(um|uh)\b/gi, ''],
+      [/\byou know\b/gi, ''],
+      [/\blike\b(?!\s+this|\s+that|\s+to)/gi, ''],
+      [/\bbasically\b/gi, ''],
+      [/\bactually\b/gi, ''],
+      [/\bjust\b(?!\s+in\s+case)/gi, ''],
+      [/\bkind of\b/gi, ''],
+      [/\bsort of\b/gi, ''],
+      [/\bi was wondering if\b/gi, ''],
+      [/\bcould you please\b/gi, 'please'],
+      [/\bwould you mind\b/gi, 'please'],
+      [/\bi would like you to\b/gi, ''],
+      [/\bif you don't mind\b/gi, ''],
+      [/\bif that's okay\b/gi, ''],
+      [/\bif possible\b/gi, ''],
+      [/\bI think\b(?!\s+that)/gi, ''],
+      [/\bI believe\b(?!\s+that)/gi, ''],
+      [/\bI guess\b/gi, ''],
+      [/\bI mean\b/gi, ''],
+    ];
+
+    for (const [pattern, replacement] of fillerRemovals) {
+      rewritten = rewritten.replace(pattern, replacement);
+    }
+
+    // Normalize whitespace
+    rewritten = rewritten.replace(/\s+/g, ' ').trim();
+    
+    // Remove duplicate punctuation
+    rewritten = rewritten.replace(/([.!?])\s*\1+/g, '$1');
+
+    return this.createResult(prompt, rewritten, originalTokens);
+  }
+}

--- a/tests/optimizer.test.ts
+++ b/tests/optimizer.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Prompt Rewriter Tests
+ * Tests for prompt optimization functionality
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PromptRewriter, type LLMProvider, type RewriterConfig } from '../src/optimization/rewriter.js';
+
+describe('PromptRewriter', () => {
+  let rewriter: PromptRewriter;
+
+  describe('with heuristic rewriting (no LLM)', () => {
+    beforeEach(() => {
+      rewriter = new PromptRewriter({ enabled: true });
+    });
+
+    it('should shorten verbose prompts', async () => {
+      const verbose = 'Um, I was wondering if you could please help me, basically I just kind of need to sort of understand how this works, you know?';
+      
+      const result = await rewriter.rewrite(verbose);
+      
+      expect(result.wasRewritten).toBe(true);
+      expect(result.rewrittenTokens).toBeLessThan(result.originalTokens);
+      expect(result.tokensSaved).toBeGreaterThan(0);
+    });
+
+    it('should preserve meaning after rewrite', async () => {
+      const original = 'I was wondering if you could please help me understand how async/await works in JavaScript';
+      
+      const result = await rewriter.rewrite(original);
+      
+      // Core concepts should be preserved
+      expect(result.rewritten.toLowerCase()).toContain('async');
+      expect(result.rewritten.toLowerCase()).toContain('await');
+      expect(result.rewritten.toLowerCase()).toContain('javascript');
+      expect(result.rewritten.toLowerCase()).toContain('help');
+    });
+
+    it('should not change already-efficient prompts', async () => {
+      const efficient = 'Explain recursion with a Python example.';
+      
+      const result = await rewriter.rewrite(efficient);
+      
+      expect(result.wasRewritten).toBe(false);
+      expect(result.rewritten).toBe(efficient);
+    });
+
+    it('should track token savings', async () => {
+      const verbose = 'Um, basically, I just kind of want you to, you know, explain this to me if you could please';
+      
+      const result = await rewriter.rewrite(verbose);
+      
+      expect(result.tokensSaved).toBeGreaterThan(0);
+      expect(result.tokensSaved).toBe(result.originalTokens - result.rewrittenTokens);
+    });
+
+    it('should pass through when disabled', async () => {
+      const disabledRewriter = new PromptRewriter({ enabled: false });
+      const prompt = 'Um, I was just wondering if, like, you could help me';
+      
+      const result = await disabledRewriter.rewrite(prompt);
+      
+      expect(result.wasRewritten).toBe(false);
+      expect(result.rewritten).toBe(prompt);
+    });
+
+    it('should not rewrite prompts with code blocks', async () => {
+      const withCode = 'Can you help me with this code?\n```javascript\nfunction test() { return 42; }\n```';
+      
+      const result = await rewriter.rewrite(withCode);
+      
+      expect(result.wasRewritten).toBe(false);
+      expect(result.rewritten).toBe(withCode);
+    });
+
+    it('should not rewrite prompts with URLs', async () => {
+      const withUrl = 'What does this page say https://example.com/article about AI?';
+      
+      const result = await rewriter.rewrite(withUrl);
+      
+      expect(result.wasRewritten).toBe(false);
+    });
+
+    it('should not rewrite prompts below minimum token threshold', async () => {
+      const short = 'Hello there!';
+      
+      const result = await rewriter.rewrite(short);
+      
+      expect(result.wasRewritten).toBe(false);
+    });
+
+    it('should remove common filler words', async () => {
+      // Prompt needs to be long enough to exceed minTokensToRewrite (20 tokens)
+      const fillers = 'Um, like, basically I just kind of need to sort of understand how this complicated system works in production, you know what I mean?';
+      
+      const result = await rewriter.rewrite(fillers);
+      
+      expect(result.wasRewritten).toBe(true);
+      expect(result.rewritten).not.toContain('Um');
+      expect(result.rewritten).not.toContain('basically');
+      expect(result.rewritten).not.toContain('kind of');
+      expect(result.rewritten).not.toContain('sort of');
+      expect(result.rewritten).not.toContain('you know');
+    });
+
+    it('should simplify polite verbose phrases', async () => {
+      const polite = 'Could you please if you would be so kind help me understand this if you don\'t mind?';
+      
+      const result = await rewriter.rewrite(polite);
+      
+      expect(result.wasRewritten).toBe(true);
+      expect(result.rewrittenTokens).toBeLessThan(result.originalTokens);
+    });
+  });
+
+  describe('with LLM provider', () => {
+    let mockProvider: LLMProvider;
+
+    beforeEach(() => {
+      mockProvider = {
+        complete: vi.fn().mockImplementation(async (prompt: string) => {
+          // Extract original prompt and return a shorter version
+          const match = prompt.match(/"""([\s\S]*?)"""/);
+          if (match) {
+            const original = match[1].trim();
+            // Simple mock: remove filler words and shorten
+            return original
+              .replace(/\bum\b|\buh\b|\blike\b|\byou know\b/gi, '')
+              .replace(/\s+/g, ' ')
+              .trim();
+          }
+          return prompt;
+        }),
+      };
+      rewriter = new PromptRewriter({ enabled: true }, mockProvider);
+    });
+
+    it('should use LLM for rewriting', async () => {
+      const verbose = 'Um, like, I was wondering if you could help me understand this concept, you know?';
+      
+      await rewriter.rewrite(verbose);
+      
+      expect(mockProvider.complete).toHaveBeenCalled();
+    });
+
+    it('should fall back to heuristic on LLM error', async () => {
+      const errorProvider: LLMProvider = {
+        complete: vi.fn().mockRejectedValue(new Error('LLM unavailable')),
+      };
+      const errorRewriter = new PromptRewriter({ enabled: true }, errorProvider);
+      
+      const verbose = 'Um, basically I just need to understand this, you know?';
+      const result = await errorRewriter.rewrite(verbose);
+      
+      // Should still return a result (from heuristic)
+      expect(result).toBeDefined();
+      expect(result.original).toBe(verbose);
+    });
+  });
+
+  describe('message rewriting', () => {
+    beforeEach(() => {
+      rewriter = new PromptRewriter({ enabled: true });
+    });
+
+    it('should rewrite the last user message', async () => {
+      const messages = [
+        { role: 'system' as const, content: 'You are helpful.' },
+        // Prompt needs to be long enough and have filler words
+        { role: 'user' as const, content: 'Um, I was just wondering if you could please help me understand this concept basically, like how does this complicated system work in production?' },
+      ];
+      
+      const { messages: newMessages, result } = await rewriter.rewriteMessages(messages);
+      
+      expect(result).toBeDefined();
+      expect(result?.wasRewritten).toBe(true);
+      expect(newMessages[1].content).not.toBe(messages[1].content);
+      // System message unchanged
+      expect(newMessages[0].content).toBe(messages[0].content);
+    });
+
+    it('should not modify messages when disabled', async () => {
+      const disabledRewriter = new PromptRewriter({ enabled: false });
+      const messages = [
+        { role: 'user' as const, content: 'Um, basically, I just need help' },
+      ];
+      
+      const { messages: newMessages, result } = await disabledRewriter.rewriteMessages(messages);
+      
+      expect(result).toBeUndefined();
+      expect(newMessages).toEqual(messages);
+    });
+
+    it('should handle messages with no user message', async () => {
+      const messages = [
+        { role: 'system' as const, content: 'You are helpful.' },
+        { role: 'assistant' as const, content: 'Hello!' },
+      ];
+      
+      const { messages: newMessages } = await rewriter.rewriteMessages(messages);
+      
+      expect(newMessages).toEqual(messages);
+    });
+  });
+
+  describe('statistics', () => {
+    beforeEach(() => {
+      rewriter = new PromptRewriter({ enabled: true });
+    });
+
+    it('should track total prompts processed', async () => {
+      await rewriter.rewrite('Hello world');
+      await rewriter.rewrite('Um basically I need help with something');
+      await rewriter.rewrite('Another prompt here');
+      
+      const stats = rewriter.getStats();
+      
+      expect(stats.totalPrompts).toBe(3);
+    });
+
+    it('should track rewritten prompts count', async () => {
+      await rewriter.rewrite('Short');  // Too short, not rewritten
+      // Longer prompt with fillers to trigger rewrite
+      await rewriter.rewrite('Um basically I just kind of need help with understanding how this complicated production system actually works in practice');
+      await rewriter.rewrite('Clear and concise prompt');  // Already efficient
+      
+      const stats = rewriter.getStats();
+      
+      expect(stats.rewrittenPrompts).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should track total tokens saved', async () => {
+      // Longer prompts with fillers to ensure they get rewritten
+      await rewriter.rewrite('Um, basically, I just kind of need to sort of understand how this complicated system works in production, you know what I mean?');
+      await rewriter.rewrite('I was wondering if you could please help me understand this concept better if you don\'t mind taking the time to explain it');
+      
+      const stats = rewriter.getStats();
+      
+      expect(stats.totalTokensSaved).toBeGreaterThan(0);
+    });
+
+    it('should reset stats', async () => {
+      await rewriter.rewrite('Um, basically test prompt');
+      
+      rewriter.resetStats();
+      const stats = rewriter.getStats();
+      
+      expect(stats.totalPrompts).toBe(0);
+      expect(stats.rewrittenPrompts).toBe(0);
+      expect(stats.totalTokensSaved).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      rewriter = new PromptRewriter({ enabled: true });
+    });
+
+    it('should handle empty string', async () => {
+      const result = await rewriter.rewrite('');
+      
+      expect(result.wasRewritten).toBe(false);
+      expect(result.rewritten).toBe('');
+    });
+
+    it('should handle whitespace-only string', async () => {
+      const result = await rewriter.rewrite('   ');
+      
+      expect(result.wasRewritten).toBe(false);
+    });
+
+    it('should handle prompt that becomes empty after rewrite', async () => {
+      // This shouldn't really happen, but test the safety
+      const result = await rewriter.rewrite('Um');
+      
+      expect(result.rewritten).toBeDefined();
+    });
+
+    it('should not make prompt longer', async () => {
+      // Mock provider that makes prompt longer
+      const badProvider: LLMProvider = {
+        complete: vi.fn().mockResolvedValue(
+          'This is a much longer rewritten version that adds unnecessary context and explanation to the original short prompt'
+        ),
+      };
+      const badRewriter = new PromptRewriter({ enabled: true }, badProvider);
+      
+      const original = 'Um, help me please understand this concept quickly';
+      const result = await badRewriter.rewrite(original);
+      
+      // Should reject the longer rewrite and return original
+      expect(result.rewrittenTokens).toBeLessThanOrEqual(result.originalTokens);
+    });
+
+    it('should preserve JSON content', async () => {
+      const jsonPrompt = '{"key": "value", "number": 42}';
+      
+      const result = await rewriter.rewrite(jsonPrompt);
+      
+      expect(result.wasRewritten).toBe(false);
+    });
+
+    it('should preserve numbered lists', async () => {
+      const listPrompt = '1. First item\n2. Second item\n3. Third item';
+      
+      const result = await rewriter.rewrite(listPrompt);
+      
+      expect(result.wasRewritten).toBe(false);
+    });
+  });
+
+  describe('configuration', () => {
+    it('should respect minTokensToRewrite setting', async () => {
+      const strictRewriter = new PromptRewriter({ 
+        enabled: true,
+        minTokensToRewrite: 100,
+      });
+      
+      const medium = 'Um basically I need help with understanding this concept please';
+      const result = await strictRewriter.rewrite(medium);
+      
+      expect(result.wasRewritten).toBe(false);
+    });
+
+    it('should respect maxSavingsPercent setting', async () => {
+      const conservativeRewriter = new PromptRewriter({ 
+        enabled: true,
+        maxSavingsPercent: 10,  // Very conservative
+      });
+      
+      const verbose = 'Um, basically, I just kind of need to sort of understand this concept, you know, if you could please help me';
+      const result = await conservativeRewriter.rewrite(verbose);
+      
+      // Should not rewrite if savings would exceed 10%
+      if (result.wasRewritten) {
+        const savingsPercent = (result.tokensSaved / result.originalTokens) * 100;
+        expect(savingsPercent).toBeLessThanOrEqual(10);
+      }
+    });
+
+    it('should allow preserveFormatting to be disabled', async () => {
+      const aggressiveRewriter = new PromptRewriter({ 
+        enabled: true,
+        preserveFormatting: false,
+      });
+      
+      // Even with code, it will try to rewrite if preserveFormatting is false
+      // and the prompt has filler words
+      const withCodeAndFillers = 'Um basically can you help with this code ```js\ntest();\n```';
+      const result = await aggressiveRewriter.rewrite(withCodeAndFillers);
+      
+      // The preserveFormatting check is bypassed
+      // (though the code block itself should still be preserved in the content)
+      expect(result).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements prompt rewriting functionality as specified in issue #14.

## Changes
- **PromptRewriter class** (`src/optimization/rewriter.ts`)
  - Heuristic rewriting (removes filler words like 'um', 'basically', 'kind of', etc.)
  - LLM-based rewriting (when provider is configured)
  - Falls back to heuristic on LLM errors
  - Message array support via `rewriteMessages()`

## Features
- Preserves code blocks, URLs, JSON, and structured content
- Configurable thresholds:
  - `minTokensToRewrite`: Skip short prompts (default: 20 tokens)
  - `maxSavingsPercent`: Cap aggressive rewrites (default: 50%)
  - `preserveFormatting`: Keep structured content intact
- Statistics tracking: total prompts, rewrites, tokens saved

## Tests
28 comprehensive tests covering:
- Heuristic rewriting
- LLM provider integration
- Message array handling
- Edge cases (empty, whitespace, JSON)
- Configuration options
- Statistics tracking

## Acceptance Criteria
- [x] Prompts are measurably shorter
- [x] No semantic information lost
- [x] Configurable on/off
- [x] Token savings tracked
- [x] Tests pass (28/28)

Closes #14