### PR TITLE
feat: Response Persistence Checker

### DIFF
--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Validation module
+ * Provides response validation including persistence claim checking
+ */
+
+export {
+  PersistenceValidator,
+  type PersistenceValidatorConfig,
+  type PersistenceClaimDetection,
+  type PersistenceCheckResult,
+  type MemoryChecker,
+  type MemoryCreator,
+} from './persistence.js';

--- a/src/validation/persistence.ts
+++ b/src/validation/persistence.ts
@@ -1,0 +1,324 @@
+/**
+ * Persistence Validator
+ * Scans agent responses for claims of remembering/logging and verifies
+ * that the memory was actually saved.
+ */
+
+export interface PersistenceValidatorConfig {
+  /** Enable/disable validation */
+  enabled: boolean;
+  /** Action to take when a false claim is detected */
+  onFalseClaim: 'auto_fix' | 'warn' | 'log_only';
+}
+
+export interface PersistenceClaimDetection {
+  /** Whether a persistence claim was detected */
+  hasClaim: boolean;
+  /** The content that was claimed to be saved */
+  claimedContent?: string;
+  /** Keywords extracted from the claim */
+  keywords?: string[];
+  /** The pattern that matched */
+  matchedPattern?: string;
+}
+
+export interface PersistenceCheckResult {
+  /** Whether the response passed validation */
+  isValid: boolean;
+  /** Whether a persistence claim was detected */
+  hasClaim: boolean;
+  /** Whether the memory was verified to exist */
+  memoryVerified?: boolean;
+  /** Whether validation was skipped (disabled) */
+  skipped?: boolean;
+  /** Whether auto-fix was applied */
+  autoFixed?: boolean;
+  /** Warning message to append (warn mode) */
+  warning?: string;
+  /** Whether the false claim was logged */
+  logged?: boolean;
+  /** The detected claim details */
+  claim?: PersistenceClaimDetection;
+}
+
+/**
+ * Interface for checking if a memory exists
+ */
+export interface MemoryChecker {
+  checkRecentMemory(agentId: string, keywords: string[]): Promise<boolean>;
+}
+
+/**
+ * Interface for creating a memory
+ */
+export interface MemoryCreator {
+  createMemory(agentId: string, content: string): Promise<void>;
+}
+
+/**
+ * Patterns that indicate a persistence claim
+ * Each pattern is a tuple of [regex, description]
+ */
+const PERSISTENCE_PATTERNS: Array<[RegExp, string]> = [
+  // Future tense remember/keep
+  [/\bi('ll| will) remember\b/i, "I'll remember"],
+  [/\bi('ll| will) keep (that|this) in mind\b/i, "I'll keep in mind"],
+  
+  // Affirmative saving/noting
+  [/\b(noted|logged|saved|recorded|stored|storing)\b(?!\?)/i, 'noted/logged/saved'],
+  
+  // Future reference
+  [/\bfor (future|later) reference\b/i, 'for future reference'],
+  
+  // Saved to memory
+  [/\bsaved? to memory\b/i, 'saved to memory'],
+  
+  // I've stored/I'm storing
+  [/\bi('ve|'m| have| am) (storing|saved|logged|recorded|noted)\b/i, "I've stored"],
+];
+
+/**
+ * Patterns that should NOT be considered persistence claims (false positives)
+ */
+const EXCLUSION_PATTERNS: RegExp[] = [
+  // Questions about remembering
+  /would you (like|want) me to remember/i,
+  /do you want me to (remember|save|note)/i,
+  /should i (remember|save|note)/i,
+  /can i (remember|note)/i,
+  
+  // Explaining capabilities (often disclaimers)
+  /i (don't|cannot|can't|do not) have (the ability|access)/i,
+  /i('m| am) (not able|unable) to (save|remember|store)/i,
+  
+  // Past tense discussion (not a claim of current action)
+  /in the past.{0,20}(noted|remembered)/i,
+  /previously.{0,20}(noted|remembered)/i,
+  
+  // Technical memory discussion
+  /\b(RAM|random.?access memory|memory (allocation|management|leak))\b/i,
+  
+  // Discussing what memories are
+  /(computer|system|device) memory/i,
+];
+
+/**
+ * Stop words to exclude from keyword extraction
+ */
+const STOP_WORDS = new Set([
+  'i', 'me', 'my', 'myself', 'we', 'our', 'ours', 'ourselves', 'you', 'your',
+  'yours', 'yourself', 'yourselves', 'he', 'him', 'his', 'himself', 'she',
+  'her', 'hers', 'herself', 'it', 'its', 'itself', 'they', 'them', 'their',
+  'theirs', 'themselves', 'what', 'which', 'who', 'whom', 'this', 'that',
+  'these', 'those', 'am', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'having', 'do', 'does', 'did', 'doing', 'a', 'an',
+  'the', 'and', 'but', 'if', 'or', 'because', 'as', 'until', 'while', 'of',
+  'at', 'by', 'for', 'with', 'about', 'against', 'between', 'into', 'through',
+  'during', 'before', 'after', 'above', 'below', 'to', 'from', 'up', 'down',
+  'in', 'out', 'on', 'off', 'over', 'under', 'again', 'further', 'then',
+  'once', 'here', 'there', 'when', 'where', 'why', 'how', 'all', 'each',
+  'few', 'more', 'most', 'other', 'some', 'such', 'no', 'nor', 'not', 'only',
+  'own', 'same', 'so', 'than', 'too', 'very', 's', 't', 'can', 'will', 'just',
+  'don', 'should', 'now', 'll', 've', 're', 'm', 'd',
+  // Additional context words
+  'that', 'remember', 'noted', 'logged', 'saved', 'stored', 'recorded',
+  'preference', 'memory', 'future', 'reference', 'keep', 'mind',
+]);
+
+export class PersistenceValidator {
+  private config: PersistenceValidatorConfig;
+  private memoryChecker?: MemoryChecker;
+  private memoryCreator?: MemoryCreator;
+
+  constructor(
+    config: Partial<PersistenceValidatorConfig> = {},
+    memoryChecker?: MemoryChecker,
+    memoryCreator?: MemoryCreator
+  ) {
+    this.config = {
+      enabled: config.enabled ?? true,
+      onFalseClaim: config.onFalseClaim ?? 'log_only',
+    };
+    this.memoryChecker = memoryChecker;
+    this.memoryCreator = memoryCreator;
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): PersistenceValidatorConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Detect if a response contains a persistence claim
+   */
+  detectPersistenceClaim(response: string): PersistenceClaimDetection {
+    // Check exclusion patterns first
+    for (const pattern of EXCLUSION_PATTERNS) {
+      if (pattern.test(response)) {
+        return { hasClaim: false };
+      }
+    }
+
+    // Check for persistence patterns
+    for (const [pattern, description] of PERSISTENCE_PATTERNS) {
+      const match = response.match(pattern);
+      if (match) {
+        // Extract the content after the claim
+        const claimedContent = this.extractClaimedContent(response, match.index || 0);
+        const keywords = this.extractKeywords(claimedContent);
+
+        return {
+          hasClaim: true,
+          claimedContent,
+          keywords,
+          matchedPattern: description,
+        };
+      }
+    }
+
+    return { hasClaim: false };
+  }
+
+  /**
+   * Extract the content that was claimed to be saved
+   */
+  private extractClaimedContent(response: string, matchIndex: number): string {
+    // Get text starting from the match
+    const afterMatch = response.slice(matchIndex);
+    
+    // Find the end of the first sentence containing the claim
+    const firstSentenceEnd = afterMatch.search(/[.!?](?:\s|$)/);
+    
+    // Check if the first sentence is very short (just the claim phrase itself)
+    // If so, include the next sentence as well
+    let endIndex: number;
+    if (firstSentenceEnd > 0 && firstSentenceEnd < 30) {
+      // Short first sentence - look for the next sentence end
+      const restOfText = afterMatch.slice(firstSentenceEnd + 1);
+      const nextSentenceEnd = restOfText.search(/[.!?](?:\s|$)/);
+      if (nextSentenceEnd > 0) {
+        endIndex = firstSentenceEnd + 1 + nextSentenceEnd + 1;
+      } else {
+        endIndex = Math.min(afterMatch.length, 200);
+      }
+    } else {
+      endIndex = firstSentenceEnd > 0 ? firstSentenceEnd + 1 : Math.min(afterMatch.length, 200);
+    }
+    
+    // Also include text before if it's part of the same sentence
+    const beforeMatch = response.slice(0, matchIndex);
+    const lastSentenceStart = Math.max(
+      beforeMatch.lastIndexOf('.') + 1,
+      beforeMatch.lastIndexOf('!') + 1,
+      beforeMatch.lastIndexOf('?') + 1,
+      0
+    );
+    
+    const fullSentence = response.slice(lastSentenceStart, matchIndex + endIndex).trim();
+    return fullSentence;
+  }
+
+  /**
+   * Extract meaningful keywords from claimed content
+   */
+  private extractKeywords(content: string): string[] {
+    // Tokenize and filter
+    const words = content
+      .toLowerCase()
+      .replace(/[^\w\s'-]/g, ' ')
+      .split(/\s+/)
+      .filter(word => word.length > 2 && !STOP_WORDS.has(word));
+
+    // Also extract proper nouns (capitalized words) from original
+    const properNouns = content.match(/[A-Z][a-z]{2,}/g) || [];
+    
+    // Combine and dedupe
+    const allKeywords = [...new Set([...words, ...properNouns.map(n => n.toLowerCase())])];
+    
+    return allKeywords.slice(0, 10); // Limit to 10 keywords
+  }
+
+  /**
+   * Validate a response for false persistence claims
+   */
+  async validate(
+    agentId: string,
+    response: string
+  ): Promise<PersistenceCheckResult> {
+    // Skip if disabled
+    if (!this.config.enabled) {
+      return {
+        isValid: true,
+        hasClaim: false,
+        skipped: true,
+      };
+    }
+
+    // Handle empty response
+    if (!response || response.trim().length === 0) {
+      return {
+        isValid: true,
+        hasClaim: false,
+      };
+    }
+
+    // Detect persistence claim
+    const claim = this.detectPersistenceClaim(response);
+    
+    if (!claim.hasClaim) {
+      return {
+        isValid: true,
+        hasClaim: false,
+      };
+    }
+
+    // Check if memory actually exists
+    let memoryVerified = false;
+    if (this.memoryChecker && claim.keywords && claim.keywords.length > 0) {
+      memoryVerified = await this.memoryChecker.checkRecentMemory(agentId, claim.keywords);
+    }
+
+    // If memory exists, claim is valid
+    if (memoryVerified) {
+      return {
+        isValid: true,
+        hasClaim: true,
+        memoryVerified: true,
+        claim,
+      };
+    }
+
+    // Memory doesn't exist - this is a false claim
+    const result: PersistenceCheckResult = {
+      isValid: false,
+      hasClaim: true,
+      memoryVerified: false,
+      claim,
+    };
+
+    // Handle based on configured action
+    switch (this.config.onFalseClaim) {
+      case 'auto_fix':
+        if (this.memoryCreator && claim.claimedContent) {
+          await this.memoryCreator.createMemory(agentId, claim.claimedContent);
+          result.autoFixed = true;
+        }
+        break;
+
+      case 'warn':
+        result.warning = '⚠️ Note: The agent claimed to remember this, but the memory may not have been saved.';
+        break;
+
+      case 'log_only':
+        console.warn(
+          `[PersistenceValidator] False persistence claim detected for agent ${agentId}: "${claim.matchedPattern}" - Content: "${claim.claimedContent?.slice(0, 100)}"`
+        );
+        result.logged = true;
+        break;
+    }
+
+    return result;
+  }
+}

--- a/tests/persistence-validator.test.ts
+++ b/tests/persistence-validator.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  PersistenceValidator,
+  type PersistenceValidatorConfig,
+  type PersistenceCheckResult,
+  type MemoryChecker,
+  type MemoryCreator,
+} from '../src/validation/persistence.js';
+
+/**
+ * Mock memory checker that returns configurable results
+ */
+function createMockMemoryChecker(hasMemory: boolean = false): MemoryChecker {
+  return {
+    async checkRecentMemory(_agentId: string, _keywords: string[]): Promise<boolean> {
+      return hasMemory;
+    },
+  };
+}
+
+/**
+ * Mock memory creator that tracks created memories
+ */
+function createMockMemoryCreator(): MemoryCreator & { createdMemories: Array<{ agentId: string; content: string }> } {
+  const creator = {
+    createdMemories: [] as Array<{ agentId: string; content: string }>,
+    async createMemory(agentId: string, content: string): Promise<void> {
+      creator.createdMemories.push({ agentId, content });
+    },
+  };
+  return creator;
+}
+
+describe('PersistenceValidator', () => {
+  describe('construction', () => {
+    it('creates with default config', () => {
+      const validator = new PersistenceValidator();
+      expect(validator).toBeDefined();
+    });
+
+    it('creates with custom config', () => {
+      const validator = new PersistenceValidator({
+        enabled: true,
+        onFalseClaim: 'warn',
+      });
+      expect(validator).toBeDefined();
+    });
+  });
+
+  describe('detectPersistenceClaim()', () => {
+    let validator: PersistenceValidator;
+
+    beforeEach(() => {
+      validator = new PersistenceValidator();
+    });
+
+    it('detects "I\'ll remember" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'll remember that you prefer dark mode"
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('dark mode');
+    });
+
+    it('detects "I will remember" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        'I will remember your preference for TypeScript'
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('TypeScript');
+    });
+
+    it('detects "noted" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        'Noted! Your birthday is March 15th.'
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('birthday');
+    });
+
+    it('detects "logged" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I've logged this preference for future reference."
+      );
+      expect(result.hasClaim).toBe(true);
+    });
+
+    it('detects "saved" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        'Saved to memory! Your favorite color is blue.'
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('blue');
+    });
+
+    it('detects "recorded" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I've recorded that you live in Santa Fe."
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('Santa Fe');
+    });
+
+    it('detects "for future reference" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'll keep that in mind for future reference - you prefer morning meetings."
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('morning meetings');
+    });
+
+    it('detects "keep that in mind" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'll keep that in mind about your allergy to peanuts."
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('peanuts');
+    });
+
+    it('detects "keep this in mind" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'll keep this in mind - you want responses under 200 words."
+      );
+      expect(result.hasClaim).toBe(true);
+    });
+
+    it('detects "storing" claim', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'm storing your timezone preference as America/Denver."
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('timezone');
+    });
+
+    it('no false positive on normal response', () => {
+      const result = validator.detectPersistenceClaim(
+        'TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.'
+      );
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('no false positive on memory-related discussion', () => {
+      const result = validator.detectPersistenceClaim(
+        'RAM (random-access memory) is a form of computer memory that can be read and changed.'
+      );
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('no false positive on past tense discussion', () => {
+      const result = validator.detectPersistenceClaim(
+        'In the past, I noted that this approach worked well.'
+      );
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('no false positive on questions about remembering', () => {
+      const result = validator.detectPersistenceClaim(
+        'Would you like me to remember this for later?'
+      );
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('no false positive on explaining memory capabilities', () => {
+      const result = validator.detectPersistenceClaim(
+        "I don't have the ability to save things to memory between sessions."
+      );
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('extracts keywords from claimed content', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'll remember that your son Noah is 8 years old and loves soccer."
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.keywords).toBeDefined();
+      expect(result.keywords?.length).toBeGreaterThan(0);
+      // Should extract meaningful keywords
+      expect(result.keywords?.some(k => k.toLowerCase().includes('noah') || k.toLowerCase().includes('soccer'))).toBe(true);
+    });
+  });
+
+  describe('validate()', () => {
+    it('returns valid when memory was actually created', async () => {
+      const checker = createMockMemoryChecker(true); // Memory exists
+      const validator = new PersistenceValidator({ enabled: true }, checker);
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasClaim).toBe(true);
+      expect(result.memoryVerified).toBe(true);
+    });
+
+    it('returns invalid when memory was not created', async () => {
+      const checker = createMockMemoryChecker(false); // No memory
+      const validator = new PersistenceValidator({ enabled: true }, checker);
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.hasClaim).toBe(true);
+      expect(result.memoryVerified).toBe(false);
+    });
+
+    it('returns valid when no persistence claim detected', async () => {
+      const checker = createMockMemoryChecker(false);
+      const validator = new PersistenceValidator({ enabled: true }, checker);
+
+      const result = await validator.validate(
+        'agent-1',
+        'TypeScript is a programming language.'
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('skips validation when disabled', async () => {
+      const checker = createMockMemoryChecker(false);
+      const validator = new PersistenceValidator({ enabled: false }, checker);
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.skipped).toBe(true);
+    });
+  });
+
+  describe('auto-fix mode', () => {
+    it('creates missing memory when onFalseClaim is auto_fix', async () => {
+      const checker = createMockMemoryChecker(false); // No memory exists
+      const creator = createMockMemoryCreator();
+      const validator = new PersistenceValidator(
+        { enabled: true, onFalseClaim: 'auto_fix' },
+        checker,
+        creator
+      );
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.autoFixed).toBe(true);
+      expect(creator.createdMemories).toHaveLength(1);
+      expect(creator.createdMemories[0].agentId).toBe('agent-1');
+      expect(creator.createdMemories[0].content).toContain('dark mode');
+    });
+
+    it('does not create memory when one already exists', async () => {
+      const checker = createMockMemoryChecker(true); // Memory exists
+      const creator = createMockMemoryCreator();
+      const validator = new PersistenceValidator(
+        { enabled: true, onFalseClaim: 'auto_fix' },
+        checker,
+        creator
+      );
+
+      await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(creator.createdMemories).toHaveLength(0);
+    });
+  });
+
+  describe('warn mode', () => {
+    it('returns warning message when onFalseClaim is warn', async () => {
+      const checker = createMockMemoryChecker(false);
+      const validator = new PersistenceValidator(
+        { enabled: true, onFalseClaim: 'warn' },
+        checker
+      );
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.warning).toBeDefined();
+      expect(result.warning).toContain('claimed');
+    });
+
+    it('provides warning that can be appended to response', async () => {
+      const checker = createMockMemoryChecker(false);
+      const validator = new PersistenceValidator(
+        { enabled: true, onFalseClaim: 'warn' },
+        checker
+      );
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.warning).toMatch(/⚠️|warning|note/i);
+    });
+  });
+
+  describe('log_only mode', () => {
+    it('only logs when onFalseClaim is log_only', async () => {
+      const checker = createMockMemoryChecker(false);
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const validator = new PersistenceValidator(
+        { enabled: true, onFalseClaim: 'log_only' },
+        checker
+      );
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.logged).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('does not auto-fix or warn in log_only mode', async () => {
+      const checker = createMockMemoryChecker(false);
+      const creator = createMockMemoryCreator();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const validator = new PersistenceValidator(
+        { enabled: true, onFalseClaim: 'log_only' },
+        checker,
+        creator
+      );
+
+      const result = await validator.validate(
+        'agent-1',
+        "I'll remember that you prefer dark mode"
+      );
+
+      expect(result.autoFixed).toBeUndefined();
+      expect(result.warning).toBeUndefined();
+      expect(creator.createdMemories).toHaveLength(0);
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe('edge cases', () => {
+    let validator: PersistenceValidator;
+    let checker: MemoryChecker;
+
+    beforeEach(() => {
+      checker = createMockMemoryChecker(false);
+      validator = new PersistenceValidator({ enabled: true }, checker);
+    });
+
+    it('handles empty response', async () => {
+      const result = await validator.validate('agent-1', '');
+      expect(result.isValid).toBe(true);
+      expect(result.hasClaim).toBe(false);
+    });
+
+    it('handles very long responses', async () => {
+      const longText = 'This is a normal sentence. '.repeat(1000) + "I'll remember that.";
+      const result = await validator.validate('agent-1', longText);
+      expect(result.hasClaim).toBe(true);
+    });
+
+    it('handles multiple claims in one response', () => {
+      const detectResult = validator.detectPersistenceClaim(
+        "I'll remember your preference for dark mode. Also noted that you like TypeScript."
+      );
+      expect(detectResult.hasClaim).toBe(true);
+      // Should extract info from both claims
+      expect(detectResult.claimedContent).toBeTruthy();
+    });
+
+    it('is case insensitive', () => {
+      const cases = [
+        "I'LL REMEMBER that",
+        "i'll remember that",
+        "I'll Remember That",
+        "NOTED!",
+        "Noted.",
+      ];
+
+      for (const text of cases) {
+        const result = validator.detectPersistenceClaim(text);
+        expect(result.hasClaim).toBe(true);
+      }
+    });
+
+    it('handles Unicode and special characters', () => {
+      const result = validator.detectPersistenceClaim(
+        "I'll remember that your name is José María 🎉"
+      );
+      expect(result.hasClaim).toBe(true);
+      expect(result.claimedContent).toContain('José');
+    });
+  });
+
+  describe('getConfig()', () => {
+    it('returns current configuration', () => {
+      const config: PersistenceValidatorConfig = {
+        enabled: true,
+        onFalseClaim: 'warn',
+      };
+      const validator = new PersistenceValidator(config);
+      
+      const returned = validator.getConfig();
+      expect(returned.enabled).toBe(true);
+      expect(returned.onFalseClaim).toBe('warn');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a PersistenceValidator class that scans LLM responses for claims of remembering/persisting information and verifies that the memory was actually saved.

## Problem
Agents frequently say things like:
- "I'll remember that"
- "Noted for future reference"
- "I've logged this"
- "Saved to memory"

...and then DON'T actually persist anything. The user thinks it's saved, but it's not.

## Solution
The `PersistenceValidator` class:
1. Scans responses for persistence claims (regex patterns)
2. Extracts keywords from the claimed content
3. Verifies against actual memory writes (via MemoryChecker interface)
4. Takes configurable action on false claims:
   - `auto_fix`: Automatically create the missing memory
   - `warn`: Append a warning to the response
   - `log_only`: Just log the false claim

## Files Added
- `src/validation/persistence.ts` - PersistenceValidator class
- `src/validation/index.ts` - Module exports
- `tests/persistence-validator.test.ts` - 34 comprehensive tests

## Tests
All 34 tests pass covering:
- Detection of various persistence claim patterns
- No false positives on questions, technical discussions, capability disclaimers
- Auto-fix, warn, and log_only modes
- Edge cases (empty responses, Unicode, long text)
- Keyword extraction

Closes #15