### PR TITLE
feat: Multi-Account Management with Routing

### DIFF
--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Accounts module - Multi-account management with routing
+ */
+
+export { AccountRegistry } from './registry.js';
+export { AccountRouter, NoAccountAvailableError } from './router.js';
+export type {
+  Provider,
+  AuthType,
+  Account,
+  AccountConfig,
+  AccountsConfig,
+  BudgetStatus,
+  MatchConditions,
+  RoutingRule,
+  RoutingContext,
+  RoutingOptions,
+  RoutingResult,
+  RoutingRulesConfig,
+} from './types.js';

--- a/src/accounts/registry.ts
+++ b/src/accounts/registry.ts
@@ -1,0 +1,206 @@
+/**
+ * Account Registry
+ * Manages multiple LLM accounts and tracks usage/budgets
+ */
+
+import type {
+  Account,
+  AccountConfig,
+  AccountsConfig,
+  BudgetStatus,
+} from './types.js';
+
+/**
+ * Registry for managing LLM accounts
+ */
+export class AccountRegistry {
+  private accounts: Map<string, Account> = new Map();
+
+  /**
+   * Create an AccountRegistry from a config object
+   */
+  static fromConfig(config: AccountsConfig): AccountRegistry {
+    const registry = new AccountRegistry();
+    
+    for (const [id, accountConfig] of Object.entries(config)) {
+      registry.register({
+        id,
+        ...accountConfig,
+      } as AccountConfig);
+    }
+    
+    return registry;
+  }
+
+  /**
+   * Register a new account
+   */
+  register(config: AccountConfig): Account {
+    const account: Account = {
+      ...config,
+      usageCurrentMonthUsd: 0,
+      enabled: true,
+    };
+    
+    this.accounts.set(config.id, account);
+    return account;
+  }
+
+  /**
+   * Get an account by ID
+   */
+  get(id: string): Account | undefined {
+    return this.accounts.get(id);
+  }
+
+  /**
+   * List all accounts
+   */
+  list(): Account[] {
+    return Array.from(this.accounts.values());
+  }
+
+  /**
+   * List accounts by provider
+   */
+  listByProvider(provider: string): Account[] {
+    return this.list().filter(account => account.provider === provider);
+  }
+
+  /**
+   * Update an existing account
+   */
+  update(id: string, updates: Partial<AccountConfig>): boolean {
+    const account = this.accounts.get(id);
+    if (!account) {
+      return false;
+    }
+    
+    // Merge updates
+    Object.assign(account, updates);
+    return true;
+  }
+
+  /**
+   * Remove an account
+   */
+  remove(id: string): boolean {
+    return this.accounts.delete(id);
+  }
+
+  /**
+   * Record usage for an account
+   * @param id Account ID
+   * @param amountUsd Amount in USD to add to current month usage
+   */
+  recordUsage(id: string, amountUsd: number): void {
+    const account = this.accounts.get(id);
+    if (!account) {
+      throw new Error(`Account not found: ${id}`);
+    }
+    
+    account.usageCurrentMonthUsd += amountUsd;
+    account.lastUsedAt = new Date();
+  }
+
+  /**
+   * Get budget status for an account
+   */
+  getBudgetStatus(id: string): BudgetStatus | undefined {
+    const account = this.accounts.get(id);
+    if (!account) {
+      return undefined;
+    }
+
+    const used = account.usageCurrentMonthUsd;
+    const budget = account.budgetMonthlyUsd;
+
+    if (budget === undefined) {
+      // No budget set - unlimited
+      return {
+        accountId: id,
+        used,
+        budget: undefined,
+        remaining: undefined,
+        percentUsed: undefined,
+        isOverBudget: false,
+        isNearBudget: false,
+      };
+    }
+
+    const remaining = budget - used;
+    const percentUsed = (used / budget) * 100;
+
+    return {
+      accountId: id,
+      used,
+      budget,
+      remaining,
+      percentUsed,
+      isOverBudget: used > budget,
+      isNearBudget: percentUsed >= 80,
+    };
+  }
+
+  /**
+   * Reset monthly usage for an account
+   */
+  resetMonthlyUsage(id: string): void {
+    const account = this.accounts.get(id);
+    if (!account) {
+      throw new Error(`Account not found: ${id}`);
+    }
+    
+    account.usageCurrentMonthUsd = 0;
+  }
+
+  /**
+   * Reset monthly usage for all accounts
+   */
+  resetAllMonthlyUsage(): void {
+    this.accounts.forEach(account => {
+      account.usageCurrentMonthUsd = 0;
+    });
+  }
+
+  /**
+   * Check if an account is available (enabled and within budget)
+   */
+  isAvailable(id: string, respectBudget: boolean = true): boolean {
+    const account = this.accounts.get(id);
+    if (!account || !account.enabled) {
+      return false;
+    }
+
+    if (!respectBudget) {
+      return true;
+    }
+
+    const status = this.getBudgetStatus(id);
+    return status ? !status.isOverBudget : true;
+  }
+
+  /**
+   * Enable an account
+   */
+  enable(id: string): boolean {
+    const account = this.accounts.get(id);
+    if (!account) {
+      return false;
+    }
+    account.enabled = true;
+    return true;
+  }
+
+  /**
+   * Disable an account
+   */
+  disable(id: string): boolean {
+    const account = this.accounts.get(id);
+    if (!account) {
+      return false;
+    }
+    account.enabled = false;
+    return true;
+  }
+}

--- a/src/accounts/router.ts
+++ b/src/accounts/router.ts
@@ -1,0 +1,239 @@
+/**
+ * Account Router
+ * Routes requests to the optimal account based on rules
+ */
+
+import type { AccountRegistry } from './registry.js';
+import type {
+  Account,
+  RoutingRule,
+  RoutingContext,
+  RoutingOptions,
+  RoutingResult,
+  MatchConditions,
+} from './types.js';
+
+/**
+ * Error thrown when no suitable account is available
+ */
+export class NoAccountAvailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NoAccountAvailableError';
+  }
+}
+
+/**
+ * Router for selecting the optimal account for a request
+ */
+export class AccountRouter {
+  private registry: AccountRegistry;
+  private rules: RoutingRule[];
+
+  constructor(registry: AccountRegistry, rules: RoutingRule[]) {
+    this.registry = registry;
+    // Sort rules by priority (highest first)
+    this.rules = [...rules].sort((a, b) => b.priority - a.priority);
+  }
+
+  /**
+   * Route a request to the optimal account
+   */
+  route(
+    context: RoutingContext,
+    options: RoutingOptions = {}
+  ): RoutingResult {
+    const { respectBudget = false, strict = false } = options;
+
+    // Find matching rule
+    const matchedRule = this.findMatchingRule(context);
+    
+    if (!matchedRule) {
+      throw new NoAccountAvailableError('No routing rules matched the request context');
+    }
+
+    // Get primary account
+    let account = this.registry.get(matchedRule.account);
+    if (!account) {
+      throw new NoAccountAvailableError(`Account not found: ${matchedRule.account}`);
+    }
+
+    // Get fallback account if defined
+    const fallback = matchedRule.fallback 
+      ? this.registry.get(matchedRule.fallback) 
+      : undefined;
+
+    // Check budget status
+    const budgetStatus = this.registry.getBudgetStatus(matchedRule.account);
+    let warning: string | undefined;
+    let reason = `Matched rule: ${matchedRule.name}`;
+
+    // Handle budget constraints
+    if (respectBudget && budgetStatus?.isOverBudget) {
+      // Try fallback
+      if (fallback) {
+        const fallbackStatus = this.registry.getBudgetStatus(fallback.id);
+        if (!fallbackStatus?.isOverBudget) {
+          account = fallback;
+          reason = `${matchedRule.account} is over budget, using fallback ${fallback.id}`;
+        } else if (strict) {
+          throw new NoAccountAvailableError(
+            `All accounts are over budget: ${matchedRule.account} and fallback ${fallback.id}`
+          );
+        } else {
+          // Use fallback even if over budget, with warning
+          account = fallback;
+          reason = `${matchedRule.account} is over budget, fallback ${fallback.id} is also over budget`;
+          warning = `All accounts are over budget`;
+        }
+      } else if (strict) {
+        throw new NoAccountAvailableError(
+          `Account ${matchedRule.account} is over budget and no fallback available`
+        );
+      } else {
+        reason = `Account ${matchedRule.account} is over budget (no fallback)`;
+        warning = `Account ${matchedRule.account} is over budget`;
+      }
+    } else if (budgetStatus?.isOverBudget) {
+      // Over budget but not respecting budget limits
+      warning = `Account ${matchedRule.account} is over budget (${budgetStatus.percentUsed?.toFixed(1)}% used)`;
+    } else if (budgetStatus?.isNearBudget) {
+      warning = `Account ${matchedRule.account} is approaching budget limit (${budgetStatus.percentUsed?.toFixed(1)}% used)`;
+    }
+
+    return {
+      account,
+      rule: matchedRule.name,
+      fallback,
+      reason,
+      warning,
+    };
+  }
+
+  /**
+   * Find the first matching rule for the given context
+   */
+  private findMatchingRule(context: RoutingContext): RoutingRule | null {
+    // First, try to find a specific rule match (not default)
+    for (const rule of this.rules) {
+      if (rule.match.default) {
+        continue; // Skip default rules in first pass
+      }
+      if (this.matchesRule(context, rule.match)) {
+        return rule;
+      }
+    }
+
+    // If no specific rule matched, find default rule
+    for (const rule of this.rules) {
+      if (rule.match.default) {
+        return rule;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if context matches rule conditions
+   */
+  private matchesRule(context: RoutingContext, match: MatchConditions): boolean {
+    // Skip default rules - they're handled specially
+    if (match.default) {
+      return false;
+    }
+
+    // Check each condition - ALL must match
+    
+    // Sensitive match
+    if (match.sensitive !== undefined) {
+      if (match.sensitive !== context.sensitive) {
+        return false;
+      }
+    }
+
+    // Agent ID pattern match
+    if (match.agentId !== undefined) {
+      if (!this.matchesPattern(context.agentId || '', match.agentId)) {
+        return false;
+      }
+    }
+
+    // Type match
+    if (match.type !== undefined) {
+      if (match.type !== context.type) {
+        return false;
+      }
+    }
+
+    // Complexity match
+    if (match.complexity !== undefined) {
+      if (match.complexity !== context.complexity) {
+        return false;
+      }
+    }
+
+    // At least one non-default condition must be specified and matched
+    const hasConditions = 
+      match.sensitive !== undefined ||
+      match.agentId !== undefined ||
+      match.type !== undefined ||
+      match.complexity !== undefined;
+
+    return hasConditions;
+  }
+
+  /**
+   * Match a value against a pattern (supports * wildcards)
+   */
+  private matchesPattern(value: string, pattern: string): boolean {
+    // Convert pattern to regex
+    // Escape special regex chars, then replace * with .*
+    const regexPattern = pattern
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/g, '.*');
+    
+    const regex = new RegExp(`^${regexPattern}$`);
+    return regex.test(value);
+  }
+
+  /**
+   * Add a new routing rule
+   */
+  addRule(rule: RoutingRule): void {
+    this.rules.push(rule);
+    this.rules.sort((a, b) => b.priority - a.priority);
+  }
+
+  /**
+   * Remove a routing rule by name
+   */
+  removeRule(name: string): boolean {
+    const index = this.rules.findIndex(r => r.name === name);
+    if (index === -1) {
+      return false;
+    }
+    this.rules.splice(index, 1);
+    return true;
+  }
+
+  /**
+   * Get all routing rules
+   */
+  getRules(): RoutingRule[] {
+    return [...this.rules];
+  }
+
+  /**
+   * Update an existing rule
+   */
+  updateRule(name: string, updates: Partial<RoutingRule>): boolean {
+    const rule = this.rules.find(r => r.name === name);
+    if (!rule) {
+      return false;
+    }
+    Object.assign(rule, updates);
+    this.rules.sort((a, b) => b.priority - a.priority);
+    return true;
+  }
+}

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Account types for multi-account management
+ */
+
+/**
+ * Supported LLM providers
+ */
+export type Provider = 'anthropic' | 'openai' | 'ollama' | 'openrouter' | 'gemini';
+
+/**
+ * Account authentication type
+ */
+export type AuthType = 'api_key' | 'oauth';
+
+/**
+ * Configuration for registering an account
+ */
+export interface AccountConfig {
+  /** Unique identifier for this account */
+  id: string;
+  /** LLM provider (anthropic, openai, ollama, etc.) */
+  provider: Provider;
+  /** Authentication type (defaults to api_key) */
+  type?: AuthType;
+  /** API key for api_key auth type */
+  apiKey?: string;
+  /** Base URL for provider (required for ollama, optional for others) */
+  baseUrl?: string;
+  /** Monthly budget in USD (optional - no limit if not set) */
+  budgetMonthlyUsd?: number;
+  /** Additional provider-specific options */
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Full account object with runtime state
+ */
+export interface Account extends AccountConfig {
+  /** Current month's usage in USD */
+  usageCurrentMonthUsd: number;
+  /** Timestamp of last usage record */
+  lastUsedAt?: Date;
+  /** Whether account is enabled */
+  enabled: boolean;
+}
+
+/**
+ * Budget status for an account
+ */
+export interface BudgetStatus {
+  /** Account ID */
+  accountId: string;
+  /** Amount used this month in USD */
+  used: number;
+  /** Monthly budget in USD (undefined if no limit) */
+  budget?: number;
+  /** Remaining budget in USD (undefined if no limit) */
+  remaining?: number;
+  /** Percentage of budget used (0-100+, undefined if no limit) */
+  percentUsed?: number;
+  /** Whether account is over budget */
+  isOverBudget: boolean;
+  /** Whether account is near budget (>80%) */
+  isNearBudget: boolean;
+}
+
+/**
+ * Match conditions for routing rules
+ */
+export interface MatchConditions {
+  /** Route if request is marked sensitive */
+  sensitive?: boolean;
+  /** Route if agent ID matches pattern (supports * wildcards) */
+  agentId?: string;
+  /** Route if request type matches */
+  type?: 'general' | 'code' | 'creative' | 'analysis' | 'chat';
+  /** Route if complexity matches */
+  complexity?: 'low' | 'medium' | 'high';
+  /** Default rule (matches when no other rules match) */
+  default?: boolean;
+  /** Custom metadata match */
+  [key: string]: unknown;
+}
+
+/**
+ * Routing rule for account selection
+ */
+export interface RoutingRule {
+  /** Rule name for identification/debugging */
+  name: string;
+  /** Conditions that trigger this rule */
+  match: MatchConditions;
+  /** Account ID to route to */
+  account: string;
+  /** Fallback account ID if primary fails or is over budget */
+  fallback?: string;
+  /** Priority (higher = evaluated first) */
+  priority: number;
+}
+
+/**
+ * Context provided when routing a request
+ */
+export interface RoutingContext {
+  /** Whether the request contains sensitive content */
+  sensitive?: boolean;
+  /** Agent ID making the request */
+  agentId?: string;
+  /** Request type */
+  type?: 'general' | 'code' | 'creative' | 'analysis' | 'chat';
+  /** Request complexity */
+  complexity?: 'low' | 'medium' | 'high';
+  /** Additional metadata for custom matching */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options for routing behavior
+ */
+export interface RoutingOptions {
+  /** Whether to respect budget limits */
+  respectBudget?: boolean;
+  /** Whether to throw error if all accounts are over budget */
+  strict?: boolean;
+}
+
+/**
+ * Result from routing decision
+ */
+export interface RoutingResult {
+  /** Selected account */
+  account: Account;
+  /** Name of the rule that matched */
+  rule: string;
+  /** Fallback account if available */
+  fallback?: Account;
+  /** Explanation of routing decision */
+  reason: string;
+  /** Warning message (e.g., budget warnings) */
+  warning?: string;
+}
+
+/**
+ * Account registry configuration (from YAML)
+ */
+export interface AccountsConfig {
+  [accountId: string]: Omit<AccountConfig, 'id'>;
+}
+
+/**
+ * Routing configuration (from YAML)
+ */
+export interface RoutingRulesConfig {
+  rules: Array<Omit<RoutingRule, 'priority'> & { priority?: number }>;
+}

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AccountRegistry } from '../src/accounts/registry.js';
+import { AccountRouter } from '../src/accounts/router.js';
+import type { Account, AccountConfig, RoutingRule, RoutingContext } from '../src/accounts/types.js';
+
+describe('AccountRegistry', () => {
+  let registry: AccountRegistry;
+
+  const testAccounts: AccountConfig[] = [
+    {
+      id: 'claude_production',
+      provider: 'anthropic',
+      apiKey: 'sk-ant-test-prod',
+      budgetMonthlyUsd: 100,
+    },
+    {
+      id: 'claude_max',
+      provider: 'anthropic',
+      type: 'oauth',
+      // OAuth tokens managed separately
+    },
+    {
+      id: 'openai_backup',
+      provider: 'openai',
+      apiKey: 'sk-openai-test',
+      budgetMonthlyUsd: 50,
+    },
+    {
+      id: 'local_private',
+      provider: 'ollama',
+      baseUrl: 'http://localhost:11434',
+      // No budget (free)
+    },
+  ];
+
+  beforeEach(() => {
+    registry = new AccountRegistry();
+    for (const account of testAccounts) {
+      registry.register(account);
+    }
+  });
+
+  describe('Account Registration', () => {
+    it('should register and retrieve accounts', () => {
+      const account = registry.get('claude_production');
+      expect(account).toBeDefined();
+      expect(account?.provider).toBe('anthropic');
+      expect(account?.id).toBe('claude_production');
+    });
+
+    it('should return undefined for unknown accounts', () => {
+      const account = registry.get('nonexistent');
+      expect(account).toBeUndefined();
+    });
+
+    it('should list all registered accounts', () => {
+      const accounts = registry.list();
+      expect(accounts).toHaveLength(4);
+      expect(accounts.map(a => a.id)).toContain('claude_production');
+      expect(accounts.map(a => a.id)).toContain('local_private');
+    });
+
+    it('should list accounts by provider', () => {
+      const anthropicAccounts = registry.listByProvider('anthropic');
+      expect(anthropicAccounts).toHaveLength(2);
+      expect(anthropicAccounts.map(a => a.id)).toContain('claude_production');
+      expect(anthropicAccounts.map(a => a.id)).toContain('claude_max');
+    });
+
+    it('should update an existing account', () => {
+      registry.update('claude_production', { budgetMonthlyUsd: 200 });
+      const account = registry.get('claude_production');
+      expect(account?.budgetMonthlyUsd).toBe(200);
+    });
+
+    it('should remove an account', () => {
+      const removed = registry.remove('openai_backup');
+      expect(removed).toBe(true);
+      expect(registry.get('openai_backup')).toBeUndefined();
+      expect(registry.list()).toHaveLength(3);
+    });
+  });
+
+  describe('Budget Tracking', () => {
+    it('should track usage for an account', () => {
+      registry.recordUsage('claude_production', 5.50);
+      const account = registry.get('claude_production');
+      expect(account?.usageCurrentMonthUsd).toBe(5.50);
+    });
+
+    it('should accumulate usage over multiple calls', () => {
+      registry.recordUsage('claude_production', 5.50);
+      registry.recordUsage('claude_production', 3.25);
+      const account = registry.get('claude_production');
+      expect(account?.usageCurrentMonthUsd).toBe(8.75);
+    });
+
+    it('should report budget status correctly', () => {
+      registry.recordUsage('claude_production', 85);
+      const status = registry.getBudgetStatus('claude_production');
+      expect(status?.used).toBe(85);
+      expect(status?.budget).toBe(100);
+      expect(status?.remaining).toBe(15);
+      expect(status?.percentUsed).toBe(85);
+      expect(status?.isOverBudget).toBe(false);
+      expect(status?.isNearBudget).toBe(true); // > 80%
+    });
+
+    it('should detect over-budget accounts', () => {
+      registry.recordUsage('claude_production', 110);
+      const status = registry.getBudgetStatus('claude_production');
+      expect(status?.isOverBudget).toBe(true);
+    });
+
+    it('should handle accounts without budgets', () => {
+      const status = registry.getBudgetStatus('local_private');
+      expect(status?.budget).toBeUndefined();
+      expect(status?.isOverBudget).toBe(false);
+    });
+
+    it('should reset monthly usage', () => {
+      registry.recordUsage('claude_production', 50);
+      registry.resetMonthlyUsage('claude_production');
+      const account = registry.get('claude_production');
+      expect(account?.usageCurrentMonthUsd).toBe(0);
+    });
+  });
+});
+
+describe('AccountRouter', () => {
+  let registry: AccountRegistry;
+  let router: AccountRouter;
+
+  const testAccounts: AccountConfig[] = [
+    {
+      id: 'claude_production',
+      provider: 'anthropic',
+      apiKey: 'sk-ant-test-prod',
+      budgetMonthlyUsd: 100,
+    },
+    {
+      id: 'claude_max',
+      provider: 'anthropic',
+      type: 'oauth',
+    },
+    {
+      id: 'openai_backup',
+      provider: 'openai',
+      apiKey: 'sk-openai-test',
+      budgetMonthlyUsd: 50,
+    },
+    {
+      id: 'local_private',
+      provider: 'ollama',
+      baseUrl: 'http://localhost:11434',
+    },
+  ];
+
+  const testRules: RoutingRule[] = [
+    {
+      name: 'sensitive-local',
+      match: { sensitive: true },
+      account: 'local_private',
+      priority: 100,
+    },
+    {
+      name: 'dev-subscription',
+      match: { agentId: 'dev-*' },
+      account: 'claude_max',
+      priority: 80,
+    },
+    {
+      name: 'production-default',
+      match: { default: true },
+      account: 'claude_production',
+      fallback: 'openai_backup',
+      priority: 0,
+    },
+  ];
+
+  beforeEach(() => {
+    registry = new AccountRegistry();
+    for (const account of testAccounts) {
+      registry.register(account);
+    }
+    router = new AccountRouter(registry, testRules);
+  });
+
+  describe('Sensitivity-Based Routing', () => {
+    it('should route sensitive content to local account', () => {
+      const context: RoutingContext = {
+        sensitive: true,
+      };
+      
+      const result = router.route(context);
+      expect(result.account.id).toBe('local_private');
+      expect(result.rule).toBe('sensitive-local');
+    });
+
+    it('should not route non-sensitive content to local', () => {
+      const context: RoutingContext = {
+        sensitive: false,
+      };
+      
+      const result = router.route(context);
+      expect(result.account.id).not.toBe('local_private');
+    });
+  });
+
+  describe('Agent ID Pattern Matching', () => {
+    it('should match agent ID with wildcard pattern', () => {
+      const context: RoutingContext = {
+        agentId: 'dev-frontend',
+      };
+      
+      const result = router.route(context);
+      expect(result.account.id).toBe('claude_max');
+      expect(result.rule).toBe('dev-subscription');
+    });
+
+    it('should match different agents with same prefix', () => {
+      const context: RoutingContext = {
+        agentId: 'dev-backend',
+      };
+      
+      const result = router.route(context);
+      expect(result.account.id).toBe('claude_max');
+    });
+
+    it('should not match agents without prefix', () => {
+      const context: RoutingContext = {
+        agentId: 'production-app',
+      };
+      
+      const result = router.route(context);
+      expect(result.account.id).toBe('claude_production'); // Falls to default
+    });
+  });
+
+  describe('Fallback Chains', () => {
+    it('should provide fallback account when primary fails', () => {
+      const context: RoutingContext = {};
+      
+      const result = router.route(context);
+      expect(result.account.id).toBe('claude_production');
+      expect(result.fallback?.id).toBe('openai_backup');
+    });
+
+    it('should use fallback when primary is over budget', () => {
+      // Put production account over budget
+      registry.recordUsage('claude_production', 110);
+      
+      const context: RoutingContext = {};
+      const result = router.route(context, { respectBudget: true });
+      
+      expect(result.account.id).toBe('openai_backup');
+      expect(result.reason).toContain('over budget');
+    });
+  });
+
+  describe('Budget Enforcement', () => {
+    it('should warn when approaching budget', () => {
+      registry.recordUsage('claude_production', 85);
+      
+      const context: RoutingContext = {};
+      const result = router.route(context);
+      
+      expect(result.warning).toContain('budget');
+    });
+
+    it('should block over-budget accounts when enforced', () => {
+      registry.recordUsage('claude_production', 110);
+      registry.recordUsage('openai_backup', 60); // Fallback also over budget
+      
+      const context: RoutingContext = {};
+      
+      expect(() => {
+        router.route(context, { respectBudget: true, strict: true });
+      }).toThrow(/budget/);
+    });
+
+    it('should allow over-budget when not enforced', () => {
+      registry.recordUsage('claude_production', 110);
+      
+      const context: RoutingContext = {};
+      const result = router.route(context, { respectBudget: false });
+      
+      expect(result.account.id).toBe('claude_production');
+      expect(result.warning).toContain('over budget');
+    });
+  });
+
+  describe('Priority Ordering', () => {
+    it('should respect rule priority', () => {
+      // Sensitive + dev agent: sensitive should win (priority 100 > 80)
+      const context: RoutingContext = {
+        sensitive: true,
+        agentId: 'dev-test',
+      };
+      
+      const result = router.route(context);
+      expect(result.account.id).toBe('local_private');
+      expect(result.rule).toBe('sensitive-local');
+    });
+  });
+
+  describe('Complex Matching', () => {
+    it('should support multiple match conditions', () => {
+      const complexRules: RoutingRule[] = [
+        {
+          name: 'prod-code',
+          match: { 
+            agentId: 'prod-*',
+            type: 'code',
+          },
+          account: 'claude_production',
+          priority: 90,
+        },
+        {
+          name: 'default',
+          match: { default: true },
+          account: 'local_private',
+          priority: 0,
+        },
+      ];
+      
+      const complexRouter = new AccountRouter(registry, complexRules);
+      
+      // Both conditions match
+      const result1 = complexRouter.route({
+        agentId: 'prod-api',
+        type: 'code',
+      });
+      expect(result1.account.id).toBe('claude_production');
+      
+      // Only one condition matches - should fall to default
+      const result2 = complexRouter.route({
+        agentId: 'prod-api',
+        type: 'chat',
+      });
+      expect(result2.account.id).toBe('local_private');
+    });
+  });
+
+  describe('Routing Result', () => {
+    it('should include routing metadata', () => {
+      const context: RoutingContext = {
+        agentId: 'dev-test',
+      };
+      
+      const result = router.route(context);
+      
+      expect(result.account).toBeDefined();
+      expect(result.rule).toBe('dev-subscription');
+      expect(result.fallback).toBeUndefined(); // dev-subscription has no fallback
+      expect(result.reason).toContain('dev-subscription');
+    });
+  });
+});
+
+describe('Account Configuration Loading', () => {
+  it('should create registry from config object', () => {
+    const config = {
+      accounts: {
+        claude_production: {
+          provider: 'anthropic',
+          apiKey: '${ANTHROPIC_API_KEY}',
+          budgetMonthlyUsd: 100,
+        },
+        local_private: {
+          provider: 'ollama',
+          baseUrl: 'http://localhost:11434',
+        },
+      },
+      routing: {
+        rules: [
+          {
+            name: 'sensitive-local',
+            match: { sensitive: true },
+            account: 'local_private',
+          },
+          {
+            name: 'default',
+            match: { default: true },
+            account: 'claude_production',
+            fallback: 'local_private',
+          },
+        ],
+      },
+    };
+    
+    const registry = AccountRegistry.fromConfig(config.accounts);
+    expect(registry.list()).toHaveLength(2);
+    expect(registry.get('claude_production')).toBeDefined();
+    expect(registry.get('local_private')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Implements Issue #17: Multi-Account Management for managing multiple LLM accounts (Claude Max, API keys, Ollama) with routing rules.

## Changes
- **AccountRegistry** (`src/accounts/registry.ts`): Central registry for managing accounts
  - Register/update/remove accounts
  - Track usage per account
  - Budget tracking with warnings and enforcement
  - List accounts by provider

- **AccountRouter** (`src/accounts/router.ts`): Routes requests to optimal account
  - Priority-based rule matching
  - Wildcard pattern matching for agent IDs (e.g., `dev-*`)
  - Sensitivity-based routing (local models for sensitive content)
  - Fallback chains when primary fails or is over budget
  - Budget enforcement options (warn/block)

- **Types** (`src/accounts/types.ts`): Complete type definitions

## Tests
26 comprehensive tests covering:
- Account registration and retrieval
- Budget tracking and enforcement
- Sensitivity-based routing
- Agent ID pattern matching
- Fallback chain behavior
- Priority ordering
- Complex multi-condition matching

Closes #17