### PR TITLE
feat(auth): Add Claude OAuth for Max subscriptions

### DIFF
--- a/src/auth/claude.ts
+++ b/src/auth/claude.ts
@@ -1,0 +1,227 @@
+/**
+ * Claude OAuth Client for Pearl
+ * Handles OAuth authentication with Claude Max subscriptions
+ */
+
+import {
+  OAuthManager,
+  OAuthConfig,
+  TokenSet,
+  OAuthError,
+  TokenExpiredError,
+  TokenRefreshError
+} from './oauth.js';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Claude-specific OAuth configuration
+ */
+export interface ClaudeOAuthConfig {
+  clientId: string;
+  clientSecret?: string;
+  redirectUri?: string;
+  scopes?: string[];
+}
+
+/**
+ * Claude OAuth endpoints
+ */
+const CLAUDE_OAUTH_ENDPOINTS = {
+  authorization: 'https://claude.ai/oauth/authorize',
+  token: 'https://claude.ai/oauth/token',
+  api: 'https://api.anthropic.com'
+};
+
+/**
+ * Default scopes for Claude Max API access
+ */
+const DEFAULT_CLAUDE_SCOPES = [
+  'user:read',
+  'messages:write',
+  'messages:read'
+];
+
+/**
+ * Provider name for token storage
+ */
+const CLAUDE_PROVIDER = 'claude';
+
+/**
+ * Claude OAuth Client
+ * Specialized client for authenticating with Claude Max subscriptions
+ */
+export class ClaudeOAuthClient {
+  private manager: OAuthManager;
+  private config: ClaudeOAuthConfig;
+
+  constructor(config: ClaudeOAuthConfig, tokenStoragePath?: string) {
+    this.config = config;
+    
+    const storagePath = tokenStoragePath || 
+      path.join(os.homedir(), '.pearl', 'auth');
+
+    const oauthConfig: OAuthConfig = {
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      authorizationEndpoint: CLAUDE_OAUTH_ENDPOINTS.authorization,
+      tokenEndpoint: CLAUDE_OAUTH_ENDPOINTS.token,
+      redirectUri: config.redirectUri || 'http://localhost:9876/callback',
+      scopes: config.scopes || DEFAULT_CLAUDE_SCOPES
+    };
+
+    this.manager = new OAuthManager(oauthConfig, storagePath);
+  }
+
+  /**
+   * Get the authorization URL to start OAuth flow
+   */
+  getAuthorizationUrl(): { url: string; state: string; codeVerifier: string } {
+    return this.manager.generateAuthorizationUrl();
+  }
+
+  /**
+   * Exchange authorization code for tokens
+   */
+  async exchangeCode(code: string, codeVerifier: string, state: string): Promise<TokenSet> {
+    const tokens = await this.manager.exchangeCode(code, codeVerifier, state);
+    await this.saveTokens(tokens);
+    return tokens;
+  }
+
+  /**
+   * Save tokens to storage
+   */
+  async saveTokens(tokens: TokenSet): Promise<void> {
+    await this.manager.saveTokens(CLAUDE_PROVIDER, tokens);
+  }
+
+  /**
+   * Load tokens from storage
+   */
+  async loadTokens(): Promise<TokenSet | null> {
+    return this.manager.loadTokens(CLAUDE_PROVIDER);
+  }
+
+  /**
+   * Delete stored tokens (logout)
+   */
+  async logout(): Promise<void> {
+    await this.manager.deleteTokens(CLAUDE_PROVIDER);
+  }
+
+  /**
+   * Check if OAuth is available (tokens exist and are valid or refreshable)
+   */
+  async isOAuthAvailable(): Promise<boolean> {
+    const tokens = await this.loadTokens();
+    
+    if (!tokens) {
+      return false;
+    }
+
+    // If token is valid, OAuth is available
+    if (this.manager.isTokenValid(tokens)) {
+      return true;
+    }
+
+    // If we have a refresh token, we might be able to refresh
+    return !!tokens.refreshToken;
+  }
+
+  /**
+   * Get a valid access token
+   */
+  async getAccessToken(): Promise<string> {
+    return this.manager.getValidAccessToken(CLAUDE_PROVIDER);
+  }
+
+  /**
+   * Make an authenticated request to Claude API
+   * Automatically handles token refresh on 401
+   */
+  async makeAuthenticatedRequest<T>(
+    endpoint: string,
+    options: RequestInit
+  ): Promise<T> {
+    let accessToken: string;
+    
+    try {
+      accessToken = await this.getAccessToken();
+    } catch (error) {
+      throw new OAuthError(
+        'Failed to get access token',
+        'NO_TOKEN',
+        { originalError: error instanceof Error ? error.message : String(error) }
+      );
+    }
+
+    const url = `${CLAUDE_OAUTH_ENDPOINTS.api}${endpoint}`;
+    
+    const headers: Record<string, string> = {
+      ...((options.headers as Record<string, string>) || {}),
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01'
+    };
+
+    const response = await fetch(url, {
+      ...options,
+      headers
+    });
+
+    // If 401, try to refresh token and retry once
+    if (response.status === 401) {
+      const tokens = await this.loadTokens();
+      
+      if (tokens?.refreshToken) {
+        try {
+          const newTokens = await this.manager.refreshTokens(tokens);
+          await this.saveTokens(newTokens);
+          
+          // Retry with new token
+          headers['Authorization'] = `Bearer ${newTokens.accessToken}`;
+          
+          const retryResponse = await fetch(url, {
+            ...options,
+            headers
+          });
+
+          if (!retryResponse.ok) {
+            const errorData = await retryResponse.json().catch(() => ({})) as Record<string, unknown>;
+            const errorObj = errorData.error as Record<string, unknown> | undefined;
+            throw new OAuthError(
+              (errorObj?.message as string) || 'Request failed after token refresh',
+              'REQUEST_FAILED',
+              errorData
+            );
+          }
+
+          return retryResponse.json() as Promise<T>;
+        } catch (refreshError) {
+          throw new TokenRefreshError(
+            'Token refresh failed during request retry',
+            { originalError: refreshError instanceof Error ? refreshError.message : String(refreshError) }
+          );
+        }
+      }
+
+      throw new TokenExpiredError('Access token expired and cannot be refreshed');
+    }
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({})) as Record<string, unknown>;
+      const errorObj = errorData.error as Record<string, unknown> | undefined;
+      throw new OAuthError(
+        (errorObj?.message as string) || `Request failed with status ${response.status}`,
+        'REQUEST_FAILED',
+        errorData
+      );
+    }
+
+    return response.json() as Promise<T>;
+  }
+}
+
+// Re-export types for convenience
+export { TokenSet, OAuthError, TokenExpiredError, TokenRefreshError } from './oauth.js';

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Auth module exports
+ */
+
+export {
+  OAuthManager,
+  OAuthConfig,
+  TokenSet,
+  AuthorizationUrlResult,
+  OAuthError,
+  TokenExpiredError,
+  TokenRefreshError
+} from './oauth.js';
+
+export {
+  ClaudeOAuthClient,
+  ClaudeOAuthConfig
+} from './claude.js';

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,0 +1,310 @@
+/**
+ * OAuth Manager for Pearl
+ * Handles OAuth 2.0 flows with PKCE support for secure token management
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * OAuth configuration for a provider
+ */
+export interface OAuthConfig {
+  clientId: string;
+  clientSecret?: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  redirectUri: string;
+  scopes: string[];
+}
+
+/**
+ * Token set returned from OAuth flow
+ */
+export interface TokenSet {
+  accessToken: string;
+  refreshToken?: string;
+  tokenType: string;
+  expiresAt: number; // Unix timestamp in milliseconds
+  scope?: string;
+}
+
+/**
+ * Authorization URL result with PKCE components
+ */
+export interface AuthorizationUrlResult {
+  url: string;
+  state: string;
+  codeVerifier: string;
+}
+
+/**
+ * Base OAuth error
+ */
+export class OAuthError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'OAuthError';
+  }
+}
+
+/**
+ * Token expired and cannot be refreshed
+ */
+export class TokenExpiredError extends OAuthError {
+  constructor(message: string = 'Token expired and no valid tokens available') {
+    super(message, 'TOKEN_EXPIRED');
+    this.name = 'TokenExpiredError';
+  }
+}
+
+/**
+ * Token refresh failed
+ */
+export class TokenRefreshError extends OAuthError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, 'TOKEN_REFRESH_FAILED', details);
+    this.name = 'TokenRefreshError';
+  }
+}
+
+/**
+ * OAuth Manager handles OAuth 2.0 authorization code flow with PKCE
+ */
+export class OAuthManager {
+  private config: OAuthConfig;
+  private tokenStoragePath: string;
+  private pendingStates: Map<string, string> = new Map(); // state -> codeVerifier
+
+  // Buffer time before token expiry (5 minutes)
+  private static readonly EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+  constructor(config: OAuthConfig, tokenStoragePath: string) {
+    this.config = config;
+    this.tokenStoragePath = tokenStoragePath;
+  }
+
+  /**
+   * Generate a secure random string for state/verifier
+   */
+  private generateSecureRandom(length: number = 32): string {
+    return crypto.randomBytes(length).toString('base64url');
+  }
+
+  /**
+   * Generate PKCE code challenge from verifier using SHA256
+   */
+  private generateCodeChallenge(verifier: string): string {
+    const hash = crypto.createHash('sha256').update(verifier).digest();
+    return hash.toString('base64url');
+  }
+
+  /**
+   * Generate the authorization URL for the OAuth flow
+   * Returns URL, state token, and PKCE code verifier
+   */
+  generateAuthorizationUrl(): AuthorizationUrlResult {
+    const state = this.generateSecureRandom();
+    const codeVerifier = this.generateSecureRandom(64);
+    const codeChallenge = this.generateCodeChallenge(codeVerifier);
+
+    // Store state -> codeVerifier mapping for later verification
+    this.pendingStates.set(state, codeVerifier);
+
+    const params = new URLSearchParams({
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      response_type: 'code',
+      scope: this.config.scopes.join(' '),
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256'
+    });
+
+    const url = `${this.config.authorizationEndpoint}?${params.toString()}`;
+
+    return { url, state, codeVerifier };
+  }
+
+  /**
+   * Exchange authorization code for tokens
+   */
+  async exchangeCode(code: string, codeVerifier: string, state: string): Promise<TokenSet> {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: this.config.redirectUri,
+      client_id: this.config.clientId,
+      code_verifier: codeVerifier
+    });
+
+    if (this.config.clientSecret) {
+      params.append('client_secret', this.config.clientSecret);
+    }
+
+    const response = await fetch(this.config.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({})) as Record<string, unknown>;
+      throw new OAuthError(
+        (errorData.error_description as string) || (errorData.error as string) || 'Token exchange failed',
+        (errorData.error as string) || 'EXCHANGE_FAILED',
+        errorData
+      );
+    }
+
+    const data = await response.json() as Record<string, unknown>;
+    
+    // Clear the pending state
+    this.pendingStates.delete(state);
+
+    return this.parseTokenResponse(data);
+  }
+
+  /**
+   * Refresh tokens using refresh token
+   */
+  async refreshTokens(tokens: TokenSet): Promise<TokenSet> {
+    if (!tokens.refreshToken) {
+      throw new TokenRefreshError('No refresh token available');
+    }
+
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: tokens.refreshToken,
+      client_id: this.config.clientId
+    });
+
+    if (this.config.clientSecret) {
+      params.append('client_secret', this.config.clientSecret);
+    }
+
+    const response = await fetch(this.config.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({})) as Record<string, unknown>;
+      throw new TokenRefreshError(
+        (errorData.error_description as string) || (errorData.error as string) || 'Token refresh failed',
+        errorData
+      );
+    }
+
+    const data = await response.json() as Record<string, unknown>;
+    const newTokens = this.parseTokenResponse(data);
+
+    // Preserve old refresh token if new one not provided
+    if (!newTokens.refreshToken && tokens.refreshToken) {
+      newTokens.refreshToken = tokens.refreshToken;
+    }
+
+    return newTokens;
+  }
+
+  /**
+   * Parse OAuth token response into TokenSet
+   */
+  private parseTokenResponse(data: Record<string, unknown>): TokenSet {
+    const expiresIn = (data.expires_in as number) || 3600;
+    const expiresAt = Date.now() + (expiresIn * 1000);
+
+    return {
+      accessToken: data.access_token as string,
+      refreshToken: data.refresh_token as string | undefined,
+      tokenType: (data.token_type as string) || 'Bearer',
+      expiresAt,
+      scope: data.scope as string | undefined
+    };
+  }
+
+  /**
+   * Check if a token is currently valid (not expired)
+   */
+  isTokenValid(tokens: TokenSet): boolean {
+    const now = Date.now();
+    return tokens.expiresAt > (now + OAuthManager.EXPIRY_BUFFER_MS);
+  }
+
+  /**
+   * Save tokens to disk
+   */
+  async saveTokens(provider: string, tokens: TokenSet): Promise<void> {
+    await fs.mkdir(this.tokenStoragePath, { recursive: true });
+    const filePath = path.join(this.tokenStoragePath, `${provider}.json`);
+    await fs.writeFile(filePath, JSON.stringify(tokens, null, 2), 'utf-8');
+  }
+
+  /**
+   * Load tokens from disk
+   */
+  async loadTokens(provider: string): Promise<TokenSet | null> {
+    const filePath = path.join(this.tokenStoragePath, `${provider}.json`);
+    try {
+      const data = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(data) as TokenSet;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Delete tokens from disk
+   */
+  async deleteTokens(provider: string): Promise<void> {
+    const filePath = path.join(this.tokenStoragePath, `${provider}.json`);
+    try {
+      await fs.unlink(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Get a valid access token, refreshing if necessary
+   */
+  async getValidAccessToken(provider: string): Promise<string> {
+    const tokens = await this.loadTokens(provider);
+    
+    if (!tokens) {
+      throw new TokenExpiredError('No tokens found');
+    }
+
+    if (this.isTokenValid(tokens)) {
+      return tokens.accessToken;
+    }
+
+    // Token expired, try to refresh
+    if (!tokens.refreshToken) {
+      throw new TokenExpiredError('Token expired and no refresh token available');
+    }
+
+    try {
+      const newTokens = await this.refreshTokens(tokens);
+      await this.saveTokens(provider, newTokens);
+      return newTokens.accessToken;
+    } catch {
+      throw new TokenExpiredError('Token expired and refresh failed');
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { Command } from 'commander';
 import { serveCommand } from './cli/serve.js';
 import { memoryCommand } from './cli/memory.js';
 import { statsCommand } from './cli/stats.js';
+import { authCommand } from './cli/auth.js';
 
 export const program = new Command();
 
@@ -20,6 +21,7 @@ program
 program.addCommand(serveCommand);
 program.addCommand(memoryCommand);
 program.addCommand(statsCommand);
+program.addCommand(authCommand);
 
 // Only parse if this is the main module (not imported for testing)
 // Check if running as CLI (not being imported)

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,0 +1,232 @@
+/**
+ * Pearl CLI Auth Commands
+ * Commands for managing OAuth authentication
+ */
+
+import { Command } from 'commander';
+import { ClaudeOAuthClient } from '../auth/claude.js';
+import { createServer } from 'http';
+import { URL } from 'url';
+
+const DEFAULT_CALLBACK_PORT = 9876;
+
+export const authCommand = new Command('auth')
+  .description('Manage authentication for model providers');
+
+/**
+ * Claude OAuth login command
+ */
+authCommand
+  .command('claude')
+  .description('Authenticate with Claude Max subscription via OAuth')
+  .option('--client-id <id>', 'OAuth client ID (or set CLAUDE_CLIENT_ID)')
+  .option('--client-secret <secret>', 'OAuth client secret (or set CLAUDE_CLIENT_SECRET)')
+  .option('--port <port>', 'Callback server port', String(DEFAULT_CALLBACK_PORT))
+  .action(async (options) => {
+    const clientId = options.clientId || process.env.CLAUDE_CLIENT_ID;
+    const clientSecret = options.clientSecret || process.env.CLAUDE_CLIENT_SECRET;
+
+    if (!clientId) {
+      console.error('Error: Claude client ID required. Set CLAUDE_CLIENT_ID or use --client-id');
+      process.exit(1);
+    }
+
+    const port = parseInt(options.port, 10);
+    const redirectUri = `http://localhost:${port}/callback`;
+
+    const client = new ClaudeOAuthClient({
+      clientId,
+      clientSecret,
+      redirectUri
+    });
+
+    console.log('Starting Claude OAuth authentication...\n');
+
+    // Generate auth URL
+    const { url, state, codeVerifier } = client.getAuthorizationUrl();
+
+    // Start local callback server
+    const server = createServer(async (req, res) => {
+      const reqUrl = new URL(req.url || '/', `http://localhost:${port}`);
+      
+      if (reqUrl.pathname === '/callback') {
+        const code = reqUrl.searchParams.get('code');
+        const returnedState = reqUrl.searchParams.get('state');
+        const error = reqUrl.searchParams.get('error');
+
+        if (error) {
+          res.writeHead(400, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="font-family: system-ui; padding: 40px; text-align: center;">
+                <h1>❌ Authentication Failed</h1>
+                <p>Error: ${error}</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          console.error(`\nAuthentication failed: ${error}`);
+          server.close();
+          process.exit(1);
+          return;
+        }
+
+        if (!code) {
+          res.writeHead(400, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="font-family: system-ui; padding: 40px; text-align: center;">
+                <h1>❌ Missing Authorization Code</h1>
+                <p>No authorization code was received.</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          console.error('\nNo authorization code received');
+          server.close();
+          process.exit(1);
+          return;
+        }
+
+        if (returnedState !== state) {
+          res.writeHead(400, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="font-family: system-ui; padding: 40px; text-align: center;">
+                <h1>❌ Security Error</h1>
+                <p>State mismatch - possible CSRF attack.</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          console.error('\nState mismatch - possible security issue');
+          server.close();
+          process.exit(1);
+          return;
+        }
+
+        try {
+          // Exchange code for tokens
+          console.log('Exchanging authorization code for tokens...');
+          const tokens = await client.exchangeCode(code, codeVerifier, state);
+          
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="font-family: system-ui; padding: 40px; text-align: center;">
+                <h1>✅ Authentication Successful!</h1>
+                <p>Pearl is now connected to your Claude Max subscription.</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+
+          console.log('\n✅ Successfully authenticated with Claude!');
+          console.log(`   Token expires: ${new Date(tokens.expiresAt).toLocaleString()}`);
+          console.log('\nYou can now use Claude Max through Pearl.');
+          
+          server.close();
+          process.exit(0);
+        } catch (err) {
+          res.writeHead(500, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="font-family: system-ui; padding: 40px; text-align: center;">
+                <h1>❌ Token Exchange Failed</h1>
+                <p>${err instanceof Error ? err.message : 'Unknown error'}</p>
+                <p>You can close this window.</p>
+              </body>
+            </html>
+          `);
+          console.error('\nToken exchange failed:', err instanceof Error ? err.message : err);
+          server.close();
+          process.exit(1);
+        }
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+    });
+
+    server.listen(port, () => {
+      console.log(`Callback server listening on http://localhost:${port}`);
+      console.log('\nOpen this URL in your browser to authenticate:\n');
+      console.log(`  ${url}\n`);
+      console.log('Waiting for authentication...');
+
+      // Try to open browser automatically
+      const { exec } = require('child_process');
+      const openCommand = process.platform === 'darwin' ? 'open' :
+                         process.platform === 'win32' ? 'start' : 'xdg-open';
+      exec(`${openCommand} "${url}"`, (err: Error | null) => {
+        if (err) {
+          // Silent fail - user can copy URL manually
+        }
+      });
+    });
+
+    // Timeout after 5 minutes
+    setTimeout(() => {
+      console.error('\nAuthentication timed out after 5 minutes.');
+      server.close();
+      process.exit(1);
+    }, 5 * 60 * 1000);
+  });
+
+/**
+ * Check auth status command
+ */
+authCommand
+  .command('status')
+  .description('Check authentication status for providers')
+  .action(async () => {
+    console.log('Authentication Status\n');
+
+    // Check Claude OAuth
+    const claudeClient = new ClaudeOAuthClient({
+      clientId: process.env.CLAUDE_CLIENT_ID || 'unknown',
+    });
+
+    const claudeAvailable = await claudeClient.isOAuthAvailable();
+    const claudeTokens = await claudeClient.loadTokens();
+
+    if (claudeAvailable && claudeTokens) {
+      const expiresAt = new Date(claudeTokens.expiresAt);
+      const isExpired = expiresAt.getTime() < Date.now();
+      
+      console.log('Claude OAuth:');
+      console.log(`  Status: ${isExpired ? '⚠️  Token expired (will refresh)' : '✅ Authenticated'}`);
+      console.log(`  Expires: ${expiresAt.toLocaleString()}`);
+      console.log(`  Has refresh token: ${claudeTokens.refreshToken ? 'Yes' : 'No'}`);
+    } else {
+      console.log('Claude OAuth:');
+      console.log('  Status: ❌ Not authenticated');
+      console.log('  Run: pearl auth claude');
+    }
+
+    // Check for API keys
+    console.log('\nAPI Keys:');
+    console.log(`  ANTHROPIC_API_KEY: ${process.env.ANTHROPIC_API_KEY ? '✅ Set' : '❌ Not set'}`);
+    console.log(`  OPENAI_API_KEY: ${process.env.OPENAI_API_KEY ? '✅ Set' : '❌ Not set'}`);
+  });
+
+/**
+ * Logout command
+ */
+authCommand
+  .command('logout')
+  .description('Remove stored authentication tokens')
+  .option('--provider <provider>', 'Provider to logout from (claude)', 'claude')
+  .action(async (options) => {
+    if (options.provider === 'claude') {
+      const client = new ClaudeOAuthClient({
+        clientId: 'unused-for-logout'
+      });
+
+      await client.logout();
+      console.log('✅ Claude OAuth tokens removed.');
+    } else {
+      console.error(`Unknown provider: ${options.provider}`);
+      process.exit(1);
+    }
+  });

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -1,0 +1,567 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { 
+  OAuthManager,
+  OAuthConfig,
+  TokenSet,
+  OAuthError,
+  TokenExpiredError,
+  TokenRefreshError
+} from '../src/auth/oauth.js';
+import {
+  ClaudeOAuthClient,
+  ClaudeOAuthConfig
+} from '../src/auth/claude.js';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('OAuthManager', () => {
+  let manager: OAuthManager;
+  let tempDir: string;
+
+  const testConfig: OAuthConfig = {
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    authorizationEndpoint: 'https://auth.example.com/authorize',
+    tokenEndpoint: 'https://auth.example.com/token',
+    redirectUri: 'http://localhost:9876/callback',
+    scopes: ['read', 'write']
+  };
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pearl-oauth-test-'));
+    manager = new OAuthManager(testConfig, tempDir);
+    mockFetch.mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('OAuth URL Generation', () => {
+    it('should generate a valid authorization URL', () => {
+      const result = manager.generateAuthorizationUrl();
+      
+      expect(result.url).toContain(testConfig.authorizationEndpoint);
+      expect(result.url).toContain(`client_id=${testConfig.clientId}`);
+      expect(result.url).toContain('redirect_uri=');
+      expect(result.url).toContain('response_type=code');
+      expect(result.url).toContain('scope=read+write');
+      expect(result.state).toBeTruthy();
+      expect(result.codeVerifier).toBeTruthy(); // PKCE
+    });
+
+    it('should include PKCE code_challenge in authorization URL', () => {
+      const result = manager.generateAuthorizationUrl();
+      
+      expect(result.url).toContain('code_challenge=');
+      expect(result.url).toContain('code_challenge_method=S256');
+    });
+
+    it('should generate unique state for each call', () => {
+      const result1 = manager.generateAuthorizationUrl();
+      const result2 = manager.generateAuthorizationUrl();
+      
+      expect(result1.state).not.toBe(result2.state);
+    });
+  });
+
+  describe('Token Exchange', () => {
+    it('should exchange authorization code for tokens', async () => {
+      const mockTokenResponse = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTokenResponse
+      });
+
+      const { codeVerifier, state } = manager.generateAuthorizationUrl();
+      const tokens = await manager.exchangeCode('test-auth-code', codeVerifier, state);
+
+      expect(tokens.accessToken).toBe('test-access-token');
+      expect(tokens.refreshToken).toBe('test-refresh-token');
+      expect(tokens.tokenType).toBe('Bearer');
+      expect(tokens.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('should handle token exchange errors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'invalid_grant', error_description: 'Invalid code' })
+      });
+
+      const { codeVerifier, state } = manager.generateAuthorizationUrl();
+      
+      await expect(manager.exchangeCode('invalid-code', codeVerifier, state))
+        .rejects.toThrow(OAuthError);
+    });
+
+    it('should include PKCE code_verifier in token exchange', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'test',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+      });
+
+      const { codeVerifier, state } = manager.generateAuthorizationUrl();
+      await manager.exchangeCode('test-code', codeVerifier, state);
+
+      // Verify fetch was called with code_verifier
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const fetchCall = mockFetch.mock.calls[0];
+      const body = fetchCall[1].body;
+      expect(body).toContain('code_verifier');
+    });
+  });
+
+  describe('Token Refresh', () => {
+    it('should refresh access token using refresh token', async () => {
+      const oldTokens: TokenSet = {
+        accessToken: 'old-access-token',
+        refreshToken: 'test-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() - 1000 // Expired
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+      });
+
+      const newTokens = await manager.refreshTokens(oldTokens);
+
+      expect(newTokens.accessToken).toBe('new-access-token');
+      expect(newTokens.refreshToken).toBe('new-refresh-token');
+      expect(newTokens.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('should throw TokenRefreshError on refresh failure', async () => {
+      const oldTokens: TokenSet = {
+        accessToken: 'old-access-token',
+        refreshToken: 'invalid-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() - 1000
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'invalid_grant' })
+      });
+
+      await expect(manager.refreshTokens(oldTokens))
+        .rejects.toThrow(TokenRefreshError);
+    });
+
+    it('should preserve refresh token if new one not provided', async () => {
+      const oldTokens: TokenSet = {
+        accessToken: 'old-access-token',
+        refreshToken: 'test-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() - 1000
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+          // Note: no refresh_token in response
+        })
+      });
+
+      const newTokens = await manager.refreshTokens(oldTokens);
+
+      expect(newTokens.refreshToken).toBe('test-refresh-token');
+    });
+  });
+
+  describe('Token Storage', () => {
+    it('should save tokens to disk', async () => {
+      const tokens: TokenSet = {
+        accessToken: 'test-access-token',
+        refreshToken: 'test-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await manager.saveTokens('claude', tokens);
+
+      const savedPath = path.join(tempDir, 'claude.json');
+      const savedData = JSON.parse(await fs.readFile(savedPath, 'utf-8'));
+      
+      expect(savedData.accessToken).toBe(tokens.accessToken);
+      expect(savedData.refreshToken).toBe(tokens.refreshToken);
+    });
+
+    it('should load tokens from disk', async () => {
+      const tokens: TokenSet = {
+        accessToken: 'test-access-token',
+        refreshToken: 'test-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await manager.saveTokens('claude', tokens);
+      const loaded = await manager.loadTokens('claude');
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.accessToken).toBe(tokens.accessToken);
+    });
+
+    it('should return null for non-existent tokens', async () => {
+      const loaded = await manager.loadTokens('nonexistent');
+      expect(loaded).toBeNull();
+    });
+
+    it('should delete tokens from disk', async () => {
+      const tokens: TokenSet = {
+        accessToken: 'test',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await manager.saveTokens('claude', tokens);
+      await manager.deleteTokens('claude');
+      
+      const loaded = await manager.loadTokens('claude');
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('Token Validity', () => {
+    it('should identify expired tokens', () => {
+      const expiredTokens: TokenSet = {
+        accessToken: 'test',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() - 1000
+      };
+
+      expect(manager.isTokenValid(expiredTokens)).toBe(false);
+    });
+
+    it('should identify valid tokens', () => {
+      const validTokens: TokenSet = {
+        accessToken: 'test',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      expect(manager.isTokenValid(validTokens)).toBe(true);
+    });
+
+    it('should consider tokens expiring soon as invalid (5 minute buffer)', () => {
+      const soonExpiringTokens: TokenSet = {
+        accessToken: 'test',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 60000 // 1 minute from now
+      };
+
+      expect(manager.isTokenValid(soonExpiringTokens)).toBe(false);
+    });
+  });
+
+  describe('Get Valid Token', () => {
+    it('should return valid token directly', async () => {
+      const validTokens: TokenSet = {
+        accessToken: 'valid-token',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await manager.saveTokens('claude', validTokens);
+      const token = await manager.getValidAccessToken('claude');
+
+      expect(token).toBe('valid-token');
+    });
+
+    it('should refresh expired token automatically', async () => {
+      const expiredTokens: TokenSet = {
+        accessToken: 'expired-token',
+        refreshToken: 'valid-refresh',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() - 1000
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+      });
+
+      await manager.saveTokens('claude', expiredTokens);
+      const token = await manager.getValidAccessToken('claude');
+
+      expect(token).toBe('new-access-token');
+    });
+
+    it('should throw TokenExpiredError when refresh fails and no tokens', async () => {
+      await expect(manager.getValidAccessToken('nonexistent'))
+        .rejects.toThrow(TokenExpiredError);
+    });
+  });
+});
+
+describe('ClaudeOAuthClient', () => {
+  let client: ClaudeOAuthClient;
+  let tempDir: string;
+
+  const testConfig: ClaudeOAuthConfig = {
+    clientId: 'claude-client-id',
+    clientSecret: 'claude-client-secret'
+  };
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pearl-claude-oauth-test-'));
+    client = new ClaudeOAuthClient(testConfig, tempDir);
+    mockFetch.mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Configuration', () => {
+    it('should use correct Claude OAuth endpoints', () => {
+      const authUrl = client.getAuthorizationUrl();
+      
+      expect(authUrl.url).toContain('https://claude.ai/oauth/authorize');
+    });
+
+    it('should request appropriate scopes for Claude Max', () => {
+      const authUrl = client.getAuthorizationUrl();
+      
+      // Should include scopes for API access
+      expect(authUrl.url).toContain('scope=');
+    });
+  });
+
+  describe('Request with OAuth Token', () => {
+    it('should make authenticated request to Claude API', async () => {
+      // Setup valid tokens
+      const validTokens: TokenSet = {
+        accessToken: 'claude-access-token',
+        refreshToken: 'claude-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await client.saveTokens(validTokens);
+
+      // Mock the Claude API call
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'msg_123',
+          content: [{ type: 'text', text: 'Hello!' }],
+          model: 'claude-3-sonnet-20240229',
+          usage: { input_tokens: 10, output_tokens: 5 }
+        })
+      });
+
+      const response = await client.makeAuthenticatedRequest('/v1/messages', {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'claude-3-sonnet-20240229',
+          max_tokens: 100,
+          messages: [{ role: 'user', content: 'Hello' }]
+        })
+      });
+
+      expect(response.id).toBe('msg_123');
+      
+      // Verify Authorization header was set
+      const fetchCall = mockFetch.mock.calls[0];
+      expect(fetchCall[1].headers['Authorization']).toBe('Bearer claude-access-token');
+    });
+
+    it('should refresh token and retry on 401', async () => {
+      // Setup expired tokens
+      const expiredTokens: TokenSet = {
+        accessToken: 'expired-access-token',
+        refreshToken: 'valid-refresh-token',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000 // Not expired by time, but will get 401
+      };
+
+      await client.saveTokens(expiredTokens);
+
+      // First call returns 401
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'invalid_token' })
+      });
+
+      // Token refresh call
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+      });
+
+      // Retry with new token succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'msg_123',
+          content: [{ type: 'text', text: 'Success!' }]
+        })
+      });
+
+      const response = await client.makeAuthenticatedRequest('/v1/messages', {
+        method: 'POST',
+        body: JSON.stringify({ model: 'claude-3-sonnet', messages: [] })
+      });
+
+      expect(response.id).toBe('msg_123');
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Fallback to API on OAuth Failure', () => {
+    it('should indicate when OAuth is unavailable', async () => {
+      // No tokens saved
+      const isAvailable = await client.isOAuthAvailable();
+      expect(isAvailable).toBe(false);
+    });
+
+    it('should indicate when OAuth is available', async () => {
+      const validTokens: TokenSet = {
+        accessToken: 'test',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await client.saveTokens(validTokens);
+      
+      const isAvailable = await client.isOAuthAvailable();
+      expect(isAvailable).toBe(true);
+    });
+
+    it('should throw OAuthError when tokens cannot be refreshed', async () => {
+      const expiredTokens: TokenSet = {
+        accessToken: 'expired',
+        refreshToken: 'invalid-refresh',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() - 1000
+      };
+
+      await client.saveTokens(expiredTokens);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'invalid_grant' })
+      });
+
+      await expect(client.getAccessToken())
+        .rejects.toThrow();
+    });
+  });
+
+  describe('Token Management', () => {
+    it('should logout and clear tokens', async () => {
+      const tokens: TokenSet = {
+        accessToken: 'test',
+        refreshToken: 'test',
+        tokenType: 'Bearer',
+        expiresAt: Date.now() + 3600000
+      };
+
+      await client.saveTokens(tokens);
+      await client.logout();
+
+      const isAvailable = await client.isOAuthAvailable();
+      expect(isAvailable).toBe(false);
+    });
+  });
+});
+
+describe('OAuth Integration', () => {
+  describe('Full OAuth Flow', () => {
+    it('should complete full OAuth flow: auth URL -> code exchange -> token storage', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pearl-oauth-flow-test-'));
+      
+      try {
+        const config: OAuthConfig = {
+          clientId: 'test-client',
+          clientSecret: 'test-secret',
+          authorizationEndpoint: 'https://auth.example.com/authorize',
+          tokenEndpoint: 'https://auth.example.com/token',
+          redirectUri: 'http://localhost:9876/callback',
+          scopes: ['api']
+        };
+
+        const manager = new OAuthManager(config, tempDir);
+
+        // Step 1: Generate auth URL
+        const { url, state, codeVerifier } = manager.generateAuthorizationUrl();
+        expect(url).toBeTruthy();
+        expect(state).toBeTruthy();
+        expect(codeVerifier).toBeTruthy();
+
+        // Step 2: Exchange code (simulated callback)
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            access_token: 'access-123',
+            refresh_token: 'refresh-456',
+            token_type: 'Bearer',
+            expires_in: 3600
+          })
+        });
+
+        const tokens = await manager.exchangeCode('auth-code-from-callback', codeVerifier, state);
+        expect(tokens.accessToken).toBe('access-123');
+
+        // Step 3: Save tokens
+        await manager.saveTokens('test-provider', tokens);
+
+        // Step 4: Retrieve and use tokens
+        const loaded = await manager.loadTokens('test-provider');
+        expect(loaded!.accessToken).toBe('access-123');
+
+        // Step 5: Get valid token (should return without refresh since not expired)
+        const validToken = await manager.getValidAccessToken('test-provider');
+        expect(validToken).toBe('access-123');
+
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements OAuth 2.0 authentication flow with PKCE support for Claude Max subscriptions, enabling Pearl to route requests through paid subscriptions instead of API credits.

## Changes

### Core OAuth Implementation (`src/auth/oauth.ts`)
- `OAuthManager` class with full OAuth 2.0 authorization code flow
- PKCE (Proof Key for Code Exchange) support for enhanced security
- Token exchange with code_verifier validation
- Automatic token refresh when expired
- Secure token storage to disk (`~/.pearl/auth/`)
- 5-minute expiry buffer to prevent edge-case failures

### Claude OAuth Client (`src/auth/claude.ts`)
- `ClaudeOAuthClient` specialized for Claude Max subscriptions
- Uses `claude.ai/oauth/authorize` and `claude.ai/oauth/token` endpoints
- Automatic 401 retry with token refresh
- `isOAuthAvailable()` method for routing decisions
- `makeAuthenticatedRequest()` for seamless API calls

### CLI Commands (`src/cli/auth.ts`)
- `pearl auth claude` - Start OAuth flow with local callback server
- `pearl auth status` - Check authentication status for all providers
- `pearl auth logout` - Remove stored tokens

## Testing

Added 28 comprehensive tests covering:
- OAuth URL generation with PKCE
- Token exchange and error handling
- Token refresh mechanics
- Token storage (save/load/delete)
- Token validity checks with expiry buffer
- Full OAuth flow integration
- Claude-specific authentication

## Usage

```bash
# Authenticate with Claude Max
pearl auth claude --client-id $CLAUDE_CLIENT_ID

# Check status
pearl auth status

# Logout
pearl auth logout
```

## Notes

- Main branch has pre-existing TypeScript build errors in `pearl.ts` and `index.ts` (unrelated to this PR)
- Main branch has 2 failing tests in `config.test.ts` (unrelated to this PR)
- All 28 OAuth tests pass

Closes #16